### PR TITLE
API calls and classes used to represent activities

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,6 +157,10 @@ dependencies {
 
     // ----------       Robolectric     ------------
     testImplementation(libs.robolectric)
+    // ----------     Retrofit     ------------
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.google.code.gson:gson:2.10")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
 
     //navigation with compose
     val nav_version = "2.7.7"

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/api/ApiResponse.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/api/ApiResponse.kt
@@ -1,13 +1,12 @@
 package com.lastaoutdoor.lasta.model.api
-
+// WIP, should be used to handle asychronous API calls, not used yet
 sealed class ApiResponse<T> {
-    /** Represents a successful response. Contains data */
-    data class Success<T>(val data: T) : ApiResponse<T>()
+  /** Represents a successful response. Contains data */
+  data class Success<T>(val data: T) : ApiResponse<T>()
 
-    /** Represents a failed response. Has information on the error
-    as a message */
-    data class Error<T>(val errorMessage: String) : ApiResponse<T>()
+  /** Represents a failed response. Has information on the error as a message */
+  data class Error<T>(val errorMessage: String) : ApiResponse<T>()
 
-    /** Represents a loading response. It may have data but it's optional */
-    data class Loading<T>(val data: T? = null) : ApiResponse<T>()
+  /** Represents a loading response. It may have data but it's optional */
+  data class Loading<T>(val data: T? = null) : ApiResponse<T>()
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/api/ApiResponse.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/api/ApiResponse.kt
@@ -1,0 +1,13 @@
+package com.lastaoutdoor.lasta.model.api
+
+sealed class ApiResponse<T> {
+    /** Represents a successful response. Contains data */
+    data class Success<T>(val data: T) : ApiResponse<T>()
+
+    /** Represents a failed response. Has information on the error
+    as a message */
+    data class Error<T>(val errorMessage: String) : ApiResponse<T>()
+
+    /** Represents a loading response. It may have data but it's optional */
+    data class Loading<T>(val data: T? = null) : ApiResponse<T>()
+}

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/api/ApiService.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/api/ApiService.kt
@@ -1,11 +1,12 @@
 package com.lastaoutdoor.lasta.model.api
+
+import com.lastaoutdoor.lasta.model.data.Node
 import retrofit2.Call
-import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.POST
 
+// interface used to formulate specific API calls
 interface ApiService {
-    @GET("interpreter?data=[out:json];area(id:3600051701)->.searchArea;(node[sport=climbing](area.searchArea););out%20geom;")
-    fun getClimbingActivity(): Call<OutdoorActivityResponse>
-
+  @GET(
+      "interpreter?data=[out:json];area(id:3600051701)->.searchArea;(node[sport=climbing](area.searchArea););out%20geom;")
+  fun getClimbingActivity(): Call<OutdoorActivityResponse<Node>>
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/api/ApiService.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/api/ApiService.kt
@@ -1,0 +1,11 @@
+package com.lastaoutdoor.lasta.model.api
+import retrofit2.Call
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface ApiService {
+    @GET("interpreter?data=[out:json];area(id:3600051701)->.searchArea;(node[sport=climbing](area.searchArea););out%20geom;")
+    fun getClimbingActivity(): Call<OutdoorActivityResponse>
+
+}

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/api/OutdoorActivityResponse.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/api/OutdoorActivityResponse.kt
@@ -1,13 +1,10 @@
-
 package com.lastaoutdoor.lasta.model.api
 
 import com.google.gson.annotations.SerializedName
-import com.lastaoutdoor.lasta.model.data.Node
+import com.lastaoutdoor.lasta.model.data.OutdoorActivity
 
-
-data class OutdoorActivityResponse(
-    @SerializedName("version")
-    val version : Float,
-    @SerializedName("elements")
-    val elements : List<Node>
+// class used by gson to convert api responses to KotlinClasses
+data class OutdoorActivityResponse<T : OutdoorActivity>(
+    @SerializedName("version") val version: Float,
+    @SerializedName("elements") val elements: List<T>
 )

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/api/OutdoorActivityResponse.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/api/OutdoorActivityResponse.kt
@@ -1,0 +1,13 @@
+
+package com.lastaoutdoor.lasta.model.api
+
+import com.google.gson.annotations.SerializedName
+import com.lastaoutdoor.lasta.model.data.Node
+
+
+data class OutdoorActivityResponse(
+    @SerializedName("version")
+    val version : Float,
+    @SerializedName("elements")
+    val elements : List<Node>
+)

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/data/ActivityType.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/data/ActivityType.kt
@@ -1,0 +1,20 @@
+package com.lastaoutdoor.lasta.model.data
+
+enum class ActivityType {
+  NULL,
+  CLIMBING {
+    override fun toString(): String {
+      return "climbing"
+    }
+  },
+  HIKING {
+    override fun toString(): String {
+      return "hiking"
+    }
+  },
+  BIKING {
+    override fun toString(): String {
+      return "biking"
+    }
+  }
+}

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/data/Node.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/data/Node.kt
@@ -1,0 +1,18 @@
+package com.lastaoutdoor.lasta.model.data
+
+import com.google.gson.annotations.SerializedName
+
+data class Node/*<T : ActivityType>*/(
+    @SerializedName("type")
+    val type : String,
+    @SerializedName("id")
+    val id: Long,
+    @SerializedName("lat")
+    val lat : Float,
+    @SerializedName("lon")
+    val lon: Float
+){
+    override fun toString(): String {
+        return (" type: $type id: $id lat: $lat lon: $lon \n")
+    }
+}

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/data/Node.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/data/Node.kt
@@ -1,18 +1,38 @@
 package com.lastaoutdoor.lasta.model.data
 
+import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 
-data class Node/*<T : ActivityType>*/(
-    @SerializedName("type")
-    val type : String,
-    @SerializedName("id")
-    val id: Long,
-    @SerializedName("lat")
-    val lat : Float,
-    @SerializedName("lon")
-    val lon: Float
+// represents OSM node
+open class Node(
+    @SerializedName("type") @Expose val type: String,
+    @SerializedName("id") @Expose val id: Long,
+    @SerializedName("lat") @Expose val lat: Float,
+    @SerializedName("lon") @Expose val lon: Float,
+    open val activityType: ActivityType = ActivityType.NULL
+) : OutdoorActivity() {
+  override fun toString(): String {
+    return (" type: $type id: $id lat: $lat lon: $lon activityType: $activityType\n")
+  }
+}
+
+/*
+
+class ClimbingNode(
+
+    type : String,
+    id: Long,
+    lat : Float,
+    lon: Float,
+    override val activityType: ActivityType = ActivityType.CLIMBING
+
+): Node(
+
+    type,
+    id, lat, lon, activityType
 ){
     override fun toString(): String {
-        return (" type: $type id: $id lat: $lat lon: $lon \n")
+        return (" type: $type id: $id lat: $lat lon: $lon activityType: $activityType\n")
     }
 }
+*/

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/data/OutdoorActivity.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/data/OutdoorActivity.kt
@@ -1,0 +1,3 @@
+package com.lastaoutdoor.lasta.model.data
+
+open class OutdoorActivity() {}

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/repository/OutdoorActivityRepository.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/repository/OutdoorActivityRepository.kt
@@ -1,40 +1,38 @@
 package com.lastaoutdoor.lasta.model.repository
-import android.telecom.Call
-import android.util.Log
-import com.lastaoutdoor.lasta.model.api.ApiResponse
+
 import com.lastaoutdoor.lasta.model.api.ApiService
 import com.lastaoutdoor.lasta.model.api.OutdoorActivityResponse
 import com.lastaoutdoor.lasta.model.data.Node
-import retrofit2.Callback
-import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-class OutdoorActivityRepository(/*context: Context*/) {
-    private val apiService: ApiService by lazy {
-        Retrofit.Builder()
-            .baseUrl("https://overpass-api.de/api/")
-            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-            .create(ApiService::class.java)
-    }
-    suspend fun getClimbingActivities(): OutdoorActivityResponse{
 
-        val call = apiService.getClimbingActivity()
-        var falseCall = false
+// Class used to get OutdoorActivities from overpass API
+class OutdoorActivityRepository(/*context: Context*/ ) {
+  // creates instance of ApiService to execute calls
+  private val apiService: ApiService by lazy {
+    Retrofit.Builder()
+        .baseUrl("https://overpass-api.de/api/")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+  }
+  // Gets Nodes of type climbing
+  suspend fun getClimbingActivities(): OutdoorActivityResponse<Node> {
 
-        val pr = call.execute()
-
-        return OutdoorActivityResponse(pr.body()!!.version, pr.body()!!.elements)
-    }
-    /**private val database = OutdoorActivityDatabase.getInstance(context)
-    private val outdoorActivityDao = database.outdoorActivityDao()
-    @@ -27,4 +69,9 @@ class OutdoorActivityRepository(context: Context) {
-    suspend fun delete(outdoorActivity: OutdoorActivity) {
-    outdoorActivityDao.delete(outdoorActivity)
-    } */
+    val call = apiService.getClimbingActivity()
+    val pr = call.execute()
+    return OutdoorActivityResponse(pr.body()!!.version, (pr.body()!!.elements))
+  }
+  /**
+   * private val database = OutdoorActivityDatabase.getInstance(context) private val
+   * outdoorActivityDao = database.outdoorActivityDao() @@ -27,4 +69,9 @@ class
+   * OutdoorActivityRepository(context: Context) { suspend fun delete(outdoorActivity:
+   * OutdoorActivity) { outdoorActivityDao.delete(outdoorActivity) }
+   */
 }
-suspend fun main(){
-    val f = OutdoorActivityRepository()
-    val q = f.getClimbingActivities()
-    println(q.elements.toString())
+// main function to test calls
+suspend fun main() {
+  val f = OutdoorActivityRepository()
+  val q = f.getClimbingActivities()
+  println(q.elements.toString())
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/model/repository/OutdoorActivityRepository.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/model/repository/OutdoorActivityRepository.kt
@@ -1,0 +1,40 @@
+package com.lastaoutdoor.lasta.model.repository
+import android.telecom.Call
+import android.util.Log
+import com.lastaoutdoor.lasta.model.api.ApiResponse
+import com.lastaoutdoor.lasta.model.api.ApiService
+import com.lastaoutdoor.lasta.model.api.OutdoorActivityResponse
+import com.lastaoutdoor.lasta.model.data.Node
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+class OutdoorActivityRepository(/*context: Context*/) {
+    private val apiService: ApiService by lazy {
+        Retrofit.Builder()
+            .baseUrl("https://overpass-api.de/api/")
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ApiService::class.java)
+    }
+    suspend fun getClimbingActivities(): OutdoorActivityResponse{
+
+        val call = apiService.getClimbingActivity()
+        var falseCall = false
+
+        val pr = call.execute()
+
+        return OutdoorActivityResponse(pr.body()!!.version, pr.body()!!.elements)
+    }
+    /**private val database = OutdoorActivityDatabase.getInstance(context)
+    private val outdoorActivityDao = database.outdoorActivityDao()
+    @@ -27,4 +69,9 @@ class OutdoorActivityRepository(context: Context) {
+    suspend fun delete(outdoorActivity: OutdoorActivity) {
+    outdoorActivityDao.delete(outdoorActivity)
+    } */
+}
+suspend fun main(){
+    val f = OutdoorActivityRepository()
+    val q = f.getClimbingActivities()
+    println(q.elements.toString())
+}


### PR DESCRIPTION
Handles API calls from Overpass Turbo (OSM data)
Added Files : 
ApiResponse.kt : used to handle asychronous API calls
ApiService.kt : interface used to formulate specific API calls
OutdoorActivityResponse.kt : class used by gson to convert api responses to Kotlin classes
ActivityType.kt : enum class to reprensent the type of different activities (e.g. climbing, hiking, .. )
OutdoorActivity.kt : reprensents most general instance of an activity
Node.kt : represents an OSM node, inherhits from OutdoorActivity
OutdoorActivityRepository.kt  : Class used to get OutdoorActivities from overpass API (i.e. class used to make requests)