### PR TITLE
Fix: Marker were not fetched when moving the camera

### DIFF
--- a/app/src/main/java/com/lastaoutdoor/lasta/data/model/activity/OutdoorActivity.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/data/model/activity/OutdoorActivity.kt
@@ -11,10 +11,10 @@ open class OutdoorActivity(
     val length: Float,
 
     /** The estimated duration of the activity. */
-    val duration: String,
+    val duration: String?,
 
     /** The canton and postal code of the activity. */
-    val locationName: String,
+    val locationName: String?,
 
     /** The geographic position of the activity. */
 ) {

--- a/app/src/main/java/com/lastaoutdoor/lasta/data/model/api/Relation.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/data/model/api/Relation.kt
@@ -14,9 +14,11 @@ class Relation(
     activityType: ActivityType,
     difficulty: Int,
     length: Float,
-    duration: String,
-    locationName: String
-) : OutdoorActivity(activityType, difficulty, length, duration, locationName) {
+    duration: String?,
+    locationName: String?
+) :
+    OutdoorActivity(
+        activityType, difficulty, length, duration ?: "not given", locationName ?: "unnamed") {
 
   override fun toString(): String {
     return (" type: $type id: $id  activityType: ${getActivityType()} name: ${tags.name} bounds: $bounds\n")

--- a/app/src/main/java/com/lastaoutdoor/lasta/data/model/api/Tags.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/data/model/api/Tags.kt
@@ -3,8 +3,8 @@ package com.lastaoutdoor.lasta.data.model.api
 import com.google.gson.annotations.SerializedName
 
 data class Tags(
-    @SerializedName(value = "name", alternate = ["from"]) val name: String,
-    @SerializedName("sport") val sport: String
+    @SerializedName(value = "name", alternate = ["from"]) val name: String?,
+    @SerializedName("sport") val sport: String?
 ) {
   override fun toString(): String {
     return "name: $name, sport: $sport"

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
@@ -104,7 +104,7 @@ fun OutdoorActivityItem(outdoorActivity: OutdoorActivity) {
                 fontWeight = FontWeight.Bold,
                 fontSize = 20.sp)
             Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.End) {
-              Text(text = outdoorActivity.locationName)
+              Text(text = outdoorActivity.locationName ?: "Unnamed Activity")
               Text(text = "Difficulty : ${outdoorActivity.difficulty}/10")
             }
           }

--- a/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/DiscoveryScreenViewModel.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/DiscoveryScreenViewModel.kt
@@ -38,7 +38,12 @@ constructor(private val repository: OutdoorActivityRepository) : ViewModel() {
 
     climbingNodes.forEach { node ->
       climbingActivities.add(
-          OutdoorActivity(ActivityType.CLIMBING, node.difficulty, node.length, "", node.tags.name))
+          OutdoorActivity(
+              ActivityType.CLIMBING,
+              node.difficulty,
+              node.length,
+              "",
+              node.tags.name ?: "Unnamed Climbing Activity"))
     }
   }
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/MapViewModel.kt
@@ -73,9 +73,9 @@ constructor(private val outdoorActivityRepository: OutdoorActivityRepository) : 
     climbingNodes.forEach {
       val marker =
           ClimbingMarker(
-              it.tags.name,
+              it.tags.name ?: "Climbing - Unnamed",
               LatLng(it.lat, it.lon),
-              it.tags.sport,
+              it.tags.sport ?: "climbing",
               BitmapDescriptorFactory.fromResource(R.drawable.climbing_icon))
       climbingMarkers.add(marker)
     }
@@ -113,9 +113,9 @@ constructor(private val outdoorActivityRepository: OutdoorActivityRepository) : 
     hikingRelations.forEach {
       markers.add(
           HikingMarker(
-              "Hiking: " + (it.tags.name),
+              "Hiking: " + (it.tags.name ?: "Unnamed"),
               LatLng(it.bounds.minlat, it.bounds.minlon),
-              it.locationName,
+              it.locationName ?: "No location name",
               BitmapDescriptorFactory.fromResource(R.drawable.hiking_icon)))
     }
 
@@ -145,7 +145,6 @@ constructor(private val outdoorActivityRepository: OutdoorActivityRepository) : 
   fun updateMarkers(centerLocation: LatLng, rad: Double) {
 
     // fetch more activity at once, so less effort when moving around
-
     try {
 
       // get all the climbing activities in the radius

--- a/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/MapViewModel.kt
@@ -135,7 +135,8 @@ constructor(private val outdoorActivityRepository: OutdoorActivityRepository) : 
         way.nodes.forEach { position -> pointsList.add(LatLng(position.lat, position.lon)) }
       }
 
-      itinerary.add(MapItinerary(relation.id, relation.tags.name, points = pointsList))
+      itinerary.add(
+          MapItinerary(relation.id, relation.tags.name ?: "No given name", points = pointsList))
     }
 
     return itinerary.toList()
@@ -144,25 +145,19 @@ constructor(private val outdoorActivityRepository: OutdoorActivityRepository) : 
   // Update the markers on the map with a new center location and radius
   fun updateMarkers(centerLocation: LatLng, rad: Double) {
 
-    // fetch more activity at once, so less effort when moving around
-    try {
+    // get all the climbing activities in the radius
+    val climbingMarkers = fetchClimbingActivities(rad, centerLocation, outdoorActivityRepository)
 
-      // get all the climbing activities in the radius
-      val climbingMarkers = fetchClimbingActivities(rad, centerLocation, outdoorActivityRepository)
+    // markers for hiking activities are still not ready due to optimization problems / api call
+    // structure
+    // val hikingRelations = fetchHikingActivities(rad, centerLocation, repository)
+    // val hikingMarkers = getMarkersFromRelations(hikingRelations)
 
-      // markers for hiking activities are still not ready due to optimization problems / api call
-      // structure
-      // val hikingRelations = fetchHikingActivities(rad, centerLocation, repository)
-      // val hikingMarkers = getMarkersFromRelations(hikingRelations)
+    // Add the markers to the map
+    state.markerList = climbingMarkers
+    // state.markerList = state.markerList.plus(hikingMarkers)
 
-      // Add the markers to the map
-      state.markerList = climbingMarkers
-      // state.markerList = state.markerList.plus(hikingMarkers)
+    // state.itineraryList = state.itineraryList.plus(getItineraryFromRelations(hikingRelations))
 
-      // state.itineraryList = state.itineraryList.plus(getItineraryFromRelations(hikingRelations))
-    } catch (e: Exception) {
-      // TODO: error message system to tell the user that the activities could not be fetched
-      e.printStackTrace()
-    }
   }
 }


### PR DESCRIPTION
### Bug description
After a big restructuration of the project, a functionnality of the map was affected: markers were not displayed anymore when the camera was moved around.

### Fix
It was an extremly dumb fix, that took me more than 2 hours to find... During the last merge, someone must have removed an elvis operator from the MapViewModel that was checking whether the activities had a valid name ( not null ) and replaced it with a placeholder otherwhise. ( The API data structures were not allowing null fields, which raised warnings about the Elvis operators. I added the '?' after the concerned fields, which resolved the warnings)

This error never crashed the program, because it was in a try catch destined for the API calls. The error was only printed in the console which made it hard to find and I was convinced it was coming from a more obscure part of the code.

### Next
I spent a considerable amount of time looking for solutions and realized that our implementation could be a lot better (new repository only for markers, different state for the asynchronous request to the api (@npfrei we can look into it together) ) and I will definitively try to ameliorate it in the future.

Moreover error handling is something we should start to implement seriously. For example show an in app message when there are some networking issues