### PR TITLE
Implementing basic search options to target activities

### DIFF
--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreenTest.kt
@@ -105,6 +105,16 @@ class DiscoveryScreenTest {
     composeRule.onNodeWithTag("localitySelectionDropdownButton").performClick()
   }
 
+  // Test the modal upper sheet
+  @Test
+  fun modalUpperSheet_isDisplayed() {
+    composeRule.activity.setContent {
+      DiscoveryScreen(navController = rememberNavController(), discoveryScreenViewModel)
+    }
+    composeRule.onNodeWithTag("listSearchOptionsEnableButton").performClick()
+    composeRule.onNodeWithTag("modalUpperSheet").assertIsDisplayed()
+  }
+
   /*
     // Test if discovery content is displayed
     @Test

--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreenTest.kt
@@ -4,10 +4,14 @@ import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import androidx.navigation.compose.rememberNavController
+import androidx.test.espresso.action.ViewActions
 import com.lastaoutdoor.lasta.data.api.FakeOutdoorActivityRepository
 import com.lastaoutdoor.lasta.di.AppModule
 import com.lastaoutdoor.lasta.ui.MainActivity
+import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenType
 import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenViewModel
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -47,6 +51,62 @@ class DiscoveryScreenTest {
     }
     composeRule.onNodeWithTag("discoveryScreen").assertIsDisplayed()
   }
+
+  // Test if modal bottom sheet is displayed on list mode correctly when isRangePopup is true
+  @Test
+  fun modalBottomSheet_isDisplayed() {
+    composeRule.activity.setContent {
+      RangeSearchComposable(
+          discoveryScreenViewModel,
+          isRangePopup = true,
+          onDismissRequest = { /*dismiss dialog on clicking "Ok"*/})
+    }
+    composeRule.onNodeWithTag("searchOptions").assertIsDisplayed()
+    // slide the slider to the right
+    composeRule
+        .onNodeWithTag("listSearchOptionsSlider")
+        .performTouchInput(block = { ViewActions.swipeRight() })
+    // change the value of the slider
+    composeRule.onNodeWithTag("listSearchOptionsSlider").performClick()
+    // click on the apply button
+    composeRule.onNodeWithTag("listSearchOptionsApplyButton").performClick()
+  }
+
+  // Test if modal bottom sheet is displayed on map mode correctly when isRangePopup is true
+  @Test
+  fun modalBottomSheet_isDisplayed_mapMode() {
+    composeRule.activity.setContent {
+      discoveryScreenViewModel.setScreen(DiscoveryScreenType.MAP)
+      RangeSearchComposable(
+          discoveryScreenViewModel,
+          isRangePopup = true,
+          onDismissRequest = { /*dismiss dialog on clicking "Ok"*/})
+    }
+    composeRule.onNodeWithTag("rangeSearch").assertIsDisplayed()
+    // slide the slider to the right
+    composeRule
+        .onNodeWithTag("mapRangeSearchSlider")
+        .performTouchInput(block = { ViewActions.swipeRight() })
+    // change the value of the slider
+    composeRule.onNodeWithTag("mapRangeSearchSlider").performClick()
+    // click on the apply button
+    composeRule.onNodeWithTag("mapRangeSearchApplyButton").performClick()
+  }
+
+  // Test the locality selection dropdown
+  @Test
+  fun localityDropdown_isDisplayed() {
+    composeRule.activity.setContent {
+      RangeSearchComposable(
+          discoveryScreenViewModel,
+          isRangePopup = true,
+          onDismissRequest = { /*dismiss dialog on clicking "Ok"*/})
+    }
+    composeRule.onNodeWithTag("localitySelectionDropdown").assertIsDisplayed()
+    // click on the locality selection dropdown
+    composeRule.onNodeWithTag("localitySelectionDropdownButton").performClick()
+  }
+
   /*
     // Test if discovery content is displayed
     @Test

--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.action.ViewActions
 import com.lastaoutdoor.lasta.data.api.FakeOutdoorActivityRepository
 import com.lastaoutdoor.lasta.di.AppModule
 import com.lastaoutdoor.lasta.ui.MainActivity
+import com.lastaoutdoor.lasta.ui.screen.discovery.components.RangeSearchComposable
 import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenType
 import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenViewModel
 import dagger.hilt.android.testing.BindValue

--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreenTest.kt
@@ -97,11 +97,9 @@ class DiscoveryScreenTest {
   @Test
   fun localityDropdown_isDisplayed() {
     composeRule.activity.setContent {
-      RangeSearchComposable(
-          discoveryScreenViewModel,
-          isRangePopup = true,
-          onDismissRequest = { /*dismiss dialog on clicking "Ok"*/})
+      DiscoveryScreen(navController = rememberNavController(), discoveryScreenViewModel)
     }
+    composeRule.onNodeWithTag("listSearchOptionsEnableButton").performClick()
     composeRule.onNodeWithTag("localitySelectionDropdown").assertIsDisplayed()
     // click on the locality selection dropdown
     composeRule.onNodeWithTag("localitySelectionDropdownButton").performClick()

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
@@ -72,23 +72,18 @@ fun DiscoveryScreen(
 ) {
   val screen by discoveryScreenViewModel.screen.collectAsState()
 
+  var isRangePopup by rememberSaveable { mutableStateOf(false) }
 
-
-    var isRangePopup by rememberSaveable { mutableStateOf(false) }
-
-    RangeSearchComposable(
-        discoveryScreenViewModel = discoveryScreenViewModel,
-        isRangePopup = isRangePopup,
-        onDismissRequest = { isRangePopup = false })
-
+  RangeSearchComposable(
+      discoveryScreenViewModel = discoveryScreenViewModel,
+      isRangePopup = isRangePopup,
+      onDismissRequest = { isRangePopup = false })
 
   if (screen == DiscoveryScreenType.LIST) {
     LazyColumn(
         modifier =
-        Modifier
-            .testTag("discoveryScreen")
-            .background(MaterialTheme.colorScheme.background)) {
-          item { HeaderComposable(updatePopup = {isRangePopup = true}) }
+            Modifier.testTag("discoveryScreen").background(MaterialTheme.colorScheme.background)) {
+          item { HeaderComposable(updatePopup = { isRangePopup = true }) }
 
           item {
             SeparatorComponent() // Add a separator between the header and the activities
@@ -98,29 +93,28 @@ fun DiscoveryScreen(
         }
   } else if (screen == DiscoveryScreenType.MAP) {
     MapScreen()
-    HeaderComposable(updatePopup = {isRangePopup = true})
+    HeaderComposable(updatePopup = { isRangePopup = true })
   }
 }
 
 @Composable
-fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltViewModel(), updatePopup: () -> Unit) {
+fun HeaderComposable(
+    discoveryScreenViewModel: DiscoveryScreenViewModel = hiltViewModel(),
+    updatePopup: () -> Unit
+) {
   val screen by discoveryScreenViewModel.screen.collectAsState()
-    val range by discoveryScreenViewModel.range.collectAsState()
-    val selectedLocality = discoveryScreenViewModel.selectedLocality.collectAsState().value
+  val range by discoveryScreenViewModel.range.collectAsState()
+  val selectedLocality = discoveryScreenViewModel.selectedLocality.collectAsState().value
   val iconSize = 48.dp // Adjust icon size as needed
 
   Surface(
-      modifier = Modifier
-          .fillMaxWidth()
-          .graphicsLayer { alpha = 0.9f },
+      modifier = Modifier.fillMaxWidth().graphicsLayer { alpha = 0.9f },
       color = MaterialTheme.colorScheme.background,
       shadowElevation = 3.dp) {
         Column {
           // Location bar
           Row(
-              modifier = Modifier
-                  .fillMaxWidth()
-                  .padding(horizontal = 16.dp, vertical = 8.dp),
+              modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
               verticalAlignment = Alignment.CenterVertically) {
                 Column {
                   Row {
@@ -134,15 +128,15 @@ fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltVi
                     }
                   }
 
-                  Text(text = "Less than ${(range / 1000).toInt()} km", style = MaterialTheme.typography.bodySmall)
+                  Text(
+                      text = "Less than ${(range / 1000).toInt()} km",
+                      style = MaterialTheme.typography.bodySmall)
                 }
               }
 
           // Search bar with toggle buttons
           Row(
-              modifier = Modifier
-                  .fillMaxWidth()
-                  .padding(horizontal = 16.dp, vertical = 8.dp),
+              modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
               verticalAlignment = Alignment.CenterVertically) {
                 SearchBarComponent(Modifier.weight(1f), onSearch = { /*TODO*/})
                 Spacer(modifier = Modifier.width(8.dp))
@@ -154,9 +148,7 @@ fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltVi
                 }
               }
           Row(
-              modifier = Modifier
-                  .fillMaxWidth()
-                  .padding(horizontal = 16.dp, vertical = 8.dp),
+              modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
               verticalAlignment = Alignment.CenterVertically,
               horizontalArrangement = Arrangement.Center) {
                 DisplaySelection(
@@ -168,9 +160,7 @@ fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltVi
 
           if (screen == DiscoveryScreenType.LIST) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically) {
                   Text("Filtering by:", style = MaterialTheme.typography.bodyMedium)
                   Spacer(modifier = Modifier.width(8.dp))
@@ -179,8 +169,7 @@ fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltVi
                       style = MaterialTheme.typography.bodyMedium,
                       color = MaterialTheme.colorScheme.primary)
 
-                  IconButton(onClick = { /*TODO*/
-                  }, modifier = Modifier.size(24.dp)) {
+                  IconButton(onClick = { /*TODO*/}, modifier = Modifier.size(24.dp)) {
                     Icon(
                         Icons.Outlined.KeyboardArrowDown,
                         contentDescription = "Filter",
@@ -202,27 +191,23 @@ fun ActivitiesDisplay(
   for (a in activities) {
     Card(
         modifier =
-        Modifier
-            .fillMaxWidth()
-            .wrapContentHeight()
-            .padding(vertical = 8.dp, horizontal = 16.dp)
-            .clickable(onClick = { navController.navigate(LeafScreen.MoreInfo.route) }),
+            Modifier.fillMaxWidth()
+                .wrapContentHeight()
+                .padding(vertical = 8.dp, horizontal = 16.dp)
+                .clickable(onClick = { navController.navigate(LeafScreen.MoreInfo.route) }),
         shape = RoundedCornerShape(8.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
     ) {
       Column {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween) {
               Box(
                   modifier =
-                  Modifier
-                      .shadow(4.dp, RoundedCornerShape(30))
-                      .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(10.dp))
-                      .padding(PaddingValues(8.dp))) {
+                      Modifier.shadow(4.dp, RoundedCornerShape(30))
+                          .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(10.dp))
+                          .padding(PaddingValues(8.dp))) {
                     Text(
                         text = "Climbing",
                         style = MaterialTheme.typography.labelMedium,
@@ -241,9 +226,7 @@ fun ActivitiesDisplay(
 
         Spacer(modifier = Modifier.height(16.dp))
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
             verticalAlignment = Alignment.CenterVertically) {
               Text(
                   text = a.locationName ?: "Unnamed Activity",
@@ -252,9 +235,7 @@ fun ActivitiesDisplay(
             }
         SeparatorComponent()
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
             verticalAlignment = Alignment.CenterVertically) {
               Icon(
                   imageVector = Icons.Default.Star,
@@ -274,166 +255,154 @@ fun ActivitiesDisplay(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RangeSearchComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltViewModel(), isRangePopup: Boolean, onDismissRequest: () -> Unit){
-    //create local variable to hold the current range whcih will then be sent as argument to the discoveryScreenViewModel.getActivities with the range
-    val range by discoveryScreenViewModel.range.collectAsState()
-    val screen by discoveryScreenViewModel.screen.collectAsState()
+fun RangeSearchComposable(
+    discoveryScreenViewModel: DiscoveryScreenViewModel = hiltViewModel(),
+    isRangePopup: Boolean,
+    onDismissRequest: () -> Unit
+) {
+  // create local variable to hold the current range whcih will then be sent as argument to the
+  // discoveryScreenViewModel.getActivities with the range
+  val range by discoveryScreenViewModel.range.collectAsState()
+  val screen by discoveryScreenViewModel.screen.collectAsState()
 
+  // list view search popup
+  if (isRangePopup && screen == DiscoveryScreenType.LIST) {
 
-    //list view search popup
-    if (isRangePopup && screen == DiscoveryScreenType.LIST) {
-
-        ModalBottomSheet(onDismissRequest = onDismissRequest, modifier = Modifier.fillMaxWidth()) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) {
-                //Select the City
-                Text(
-                    text = "Select the locality",
-                    style = TextStyle(
-                        fontSize = 16.sp,
-                        lineHeight = 24.sp,
-                        fontWeight = FontWeight(500)
-                    ))
-                Spacer(modifier = Modifier.height(8.dp))
-                //Dropdown to select the city
-                CitySelectionDropdown(discoveryScreenViewModel)
-                //Select the distance radius
-                Text(
-                    text = "Select the distance radius",
-                    style = TextStyle(
-                        fontSize = 16.sp,
-                        lineHeight = 24.sp,
-                        fontWeight = FontWeight(500)
-                    ))
-                Spacer(modifier = Modifier.height(8.dp))
-                //Slider to select the range
-                Row {
-                    Slider(
-                        value = range.toFloat(),
-                        onValueChange = {  discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0)) },
-                        valueRange = 0f..50000f,
-                        steps = 100,
-                        modifier = Modifier.width(305.dp)
-                    )
-                    Text(
-                        //put range in km
-                        text = "${(range / 1000).toInt()} km",
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(8.dp)
-                    )
-                }
-
-                //Button to apply the range
-                ElevatedButton(
-                    onClick = {
-                        discoveryScreenViewModel.fetchClimbingActivities(range, discoveryScreenViewModel.selectedLocality.value.second)
-                        onDismissRequest()
-                    },
-                    modifier = Modifier
-                        .width(305.dp)
-                        .height(48.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
-                    Text(
-                        "Search",
-                        style =
-                        TextStyle(
-                            fontSize = 22.sp,
-                            lineHeight = 28.sp,
-                            fontWeight = FontWeight(400),
-                        )
-                    )
-                }
+    ModalBottomSheet(onDismissRequest = onDismissRequest, modifier = Modifier.fillMaxWidth()) {
+      Column(
+          horizontalAlignment = Alignment.CenterHorizontally,
+          modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            // Select the City
+            Text(
+                text = "Select the locality",
+                style =
+                    TextStyle(fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+            Spacer(modifier = Modifier.height(8.dp))
+            // Dropdown to select the city
+            CitySelectionDropdown(discoveryScreenViewModel)
+            // Select the distance radius
+            Text(
+                text = "Select the distance radius",
+                style =
+                    TextStyle(fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+            Spacer(modifier = Modifier.height(8.dp))
+            // Slider to select the range
+            Row {
+              Slider(
+                  value = range.toFloat(),
+                  onValueChange = {
+                    discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
+                  },
+                  valueRange = 0f..50000f,
+                  steps = 100,
+                  modifier = Modifier.width(305.dp))
+              Text(
+                  // put range in km
+                  text = "${(range / 1000).toInt()} km",
+                  style = MaterialTheme.typography.bodyMedium,
+                  modifier = Modifier.padding(8.dp))
             }
-        }
+
+            // Button to apply the range
+            ElevatedButton(
+                onClick = {
+                  discoveryScreenViewModel.fetchClimbingActivities(
+                      range, discoveryScreenViewModel.selectedLocality.value.second)
+                  onDismissRequest()
+                },
+                modifier = Modifier.width(305.dp).height(48.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+                  Text(
+                      "Search",
+                      style =
+                          TextStyle(
+                              fontSize = 22.sp,
+                              lineHeight = 28.sp,
+                              fontWeight = FontWeight(400),
+                          ))
+                }
+          }
     }
+  }
 
-    //map range search popup
-    if (isRangePopup && screen == DiscoveryScreenType.MAP) {
-        ModalBottomSheet(onDismissRequest = onDismissRequest, modifier = Modifier.fillMaxWidth()) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) {
-                Text(
-                    text = "Select the distance",
-                    style = TextStyle(
-                        fontSize = 16.sp,
-                        lineHeight = 24.sp,
-                        fontWeight = FontWeight(500)
-                ))
-                Spacer(modifier = Modifier.height(8.dp))
-                //Slider to select the range
-                Row {
-                    Slider(
-                        value = range.toFloat(),
-                        onValueChange = { discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0)) },
-                        valueRange = 0f..50000f,
-                        steps = 100,
-                        modifier = Modifier.width(305.dp)
-                    )
-                    Text(
-                        //put range in km
-                        text = "${(range / 1000).toInt()} km",
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(8.dp)
-                    )
-                }
-
-                //Button to apply the range
-                ElevatedButton(
-                    onClick = {
-                        //discoveryScreenViewModel.getActivities(range)
-                        onDismissRequest()
-                    },
-                    modifier = Modifier
-                        .width(305.dp)
-                        .height(48.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
-                    Text(
-                        "Apply",
-                        style =
-                        TextStyle(
-                            fontSize = 22.sp,
-                            lineHeight = 28.sp,
-                            fontWeight = FontWeight(400),
-                        )
-                    )
-                }
+  // map range search popup
+  if (isRangePopup && screen == DiscoveryScreenType.MAP) {
+    ModalBottomSheet(onDismissRequest = onDismissRequest, modifier = Modifier.fillMaxWidth()) {
+      Column(
+          horizontalAlignment = Alignment.CenterHorizontally,
+          modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Text(
+                text = "Select the distance",
+                style =
+                    TextStyle(fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+            Spacer(modifier = Modifier.height(8.dp))
+            // Slider to select the range
+            Row {
+              Slider(
+                  value = range.toFloat(),
+                  onValueChange = {
+                    discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
+                  },
+                  valueRange = 0f..50000f,
+                  steps = 100,
+                  modifier = Modifier.width(305.dp))
+              Text(
+                  // put range in km
+                  text = "${(range / 1000).toInt()} km",
+                  style = MaterialTheme.typography.bodyMedium,
+                  modifier = Modifier.padding(8.dp))
             }
-        }
+
+            // Button to apply the range
+            ElevatedButton(
+                onClick = {
+                  discoveryScreenViewModel.fetchClimbingActivities(
+                      range, discoveryScreenViewModel.selectedLocality.value.second)
+                  onDismissRequest()
+                },
+                modifier = Modifier.width(305.dp).height(48.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+                  Text(
+                      "Apply",
+                      style =
+                          TextStyle(
+                              fontSize = 22.sp,
+                              lineHeight = 28.sp,
+                              fontWeight = FontWeight(400),
+                          ))
+                }
+          }
     }
+  }
 }
 
-//Dropdown to select the city
+// Dropdown to select the city
 @Composable
 fun CitySelectionDropdown(discoveryScreenViewModel: DiscoveryScreenViewModel) {
-    var expanded by remember { mutableStateOf(false) }
-    val localities = discoveryScreenViewModel.localities
-    var selectedLocality = discoveryScreenViewModel.selectedLocality.collectAsState().value
+  var expanded by remember { mutableStateOf(false) }
+  val localities = discoveryScreenViewModel.localities
+  var selectedLocality = discoveryScreenViewModel.selectedLocality.collectAsState().value
 
-    Box(modifier = Modifier.wrapContentSize()) {
-        Text(selectedLocality.first, modifier = Modifier.clickable(onClick = { expanded = true }), style = TextStyle(
-            fontSize = 22.sp,
-            lineHeight = 28.sp,
-            fontWeight = FontWeight(400),
-            color = AccentGreen
-        ))
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            localities.forEach { locality ->
-                DropdownMenuItem(
-                    text = { Text(locality.first, color = AccentGreen) },
-                    onClick = {
-                        discoveryScreenViewModel.setSelectedLocality(locality)
-                        expanded = false
-                })
-            }
-        }
+  Box(modifier = Modifier.wrapContentSize()) {
+    Text(
+        selectedLocality.first,
+        modifier = Modifier.clickable(onClick = { expanded = true }),
+        style =
+            TextStyle(
+                fontSize = 22.sp,
+                lineHeight = 28.sp,
+                fontWeight = FontWeight(400),
+                color = AccentGreen))
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+      localities.forEach { locality ->
+        DropdownMenuItem(
+            text = { Text(locality.first, color = AccentGreen) },
+            onClick = {
+              discoveryScreenViewModel.setSelectedLocality(locality)
+              expanded = false
+            })
+      }
     }
-    Spacer(modifier = Modifier.height(8.dp))
+  }
+  Spacer(modifier = Modifier.height(8.dp))
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
@@ -14,34 +14,23 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ElevatedButton
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -50,10 +39,8 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.lastaoutdoor.lasta.R
@@ -61,9 +48,9 @@ import com.lastaoutdoor.lasta.ui.components.DisplaySelection
 import com.lastaoutdoor.lasta.ui.components.SearchBarComponent
 import com.lastaoutdoor.lasta.ui.components.SeparatorComponent
 import com.lastaoutdoor.lasta.ui.navigation.LeafScreen
+import com.lastaoutdoor.lasta.ui.screen.discovery.components.ModalUpperSheet
+import com.lastaoutdoor.lasta.ui.screen.discovery.components.RangeSearchComposable
 import com.lastaoutdoor.lasta.ui.screen.map.MapScreen
-import com.lastaoutdoor.lasta.ui.theme.AccentGreen
-import com.lastaoutdoor.lasta.ui.theme.PrimaryBlue
 import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenType
 import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenViewModel
 
@@ -258,225 +245,4 @@ fun ActivitiesDisplay(
       }
     }
   }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun RangeSearchComposable(
-    discoveryScreenViewModel: DiscoveryScreenViewModel = hiltViewModel(),
-    isRangePopup: Boolean,
-    onDismissRequest: () -> Unit
-) {
-  // create local variable to hold the current range whcih will then be sent as argument to the
-  // discoveryScreenViewModel.getActivities with the range
-  val range by discoveryScreenViewModel.range.collectAsState()
-  val screen by discoveryScreenViewModel.screen.collectAsState()
-
-  // list view search popup
-  if (isRangePopup && screen == DiscoveryScreenType.LIST) {
-
-    ModalBottomSheet(
-        onDismissRequest = onDismissRequest,
-        modifier = Modifier.fillMaxWidth().testTag("searchOptions")) {
-          Column(
-              horizontalAlignment = Alignment.CenterHorizontally,
-              modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-                // Select the City
-                Text(
-                    text = "Locality :",
-                    style =
-                        TextStyle(
-                            fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
-                Spacer(modifier = Modifier.height(8.dp))
-                // Dropdown to select the city
-                LocalitySelectionDropdown(discoveryScreenViewModel)
-                // Select the distance radius
-                Text(
-                    text = "Distance radius :",
-                    style =
-                        TextStyle(
-                            fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
-                Spacer(modifier = Modifier.height(8.dp))
-                // Slider to select the range
-                Row {
-                  Slider(
-                      value = range.toFloat(),
-                      onValueChange = {
-                        discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
-                      },
-                      valueRange = 0f..50000f,
-                      steps = 100,
-                      modifier = Modifier.width(300.dp).testTag("listSearchOptionsSlider"))
-                  Text(
-                      // put range in km
-                      text = "${(range / 1000).toInt()}km",
-                      style = MaterialTheme.typography.bodyMedium,
-                      modifier = Modifier.padding(8.dp))
-                }
-
-                // Button to apply the range
-                ElevatedButton(
-                    onClick = {
-                      discoveryScreenViewModel.fetchClimbingActivities(
-                          range, discoveryScreenViewModel.selectedLocality.value.second)
-                      onDismissRequest()
-                    },
-                    modifier =
-                        Modifier.width(305.dp)
-                            .height(48.dp)
-                            .testTag("listSearchOptionsApplyButton"),
-                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
-                      Text(
-                          "Search",
-                          style =
-                              TextStyle(
-                                  fontSize = 22.sp,
-                                  lineHeight = 28.sp,
-                                  fontWeight = FontWeight(400),
-                              ))
-                    }
-              }
-        }
-  }
-
-  // map range search popup
-  if (isRangePopup && screen == DiscoveryScreenType.MAP) {
-    ModalBottomSheet(
-        onDismissRequest = onDismissRequest,
-        modifier = Modifier.fillMaxWidth().testTag("rangeSearch")) {
-          Column(
-              horizontalAlignment = Alignment.CenterHorizontally,
-              modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-                Text(
-                    text = "Select the distance radius",
-                    style =
-                        TextStyle(
-                            fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
-                // Slider to select the range
-                Row {
-                  Slider(
-                      value = range.toFloat(),
-                      onValueChange = {
-                        discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
-                      },
-                      valueRange = 0f..50000f,
-                      steps = 100,
-                      modifier = Modifier.width(300.dp).testTag("mapRangeSearchSlider"))
-                  Text(
-                      // put range in km
-                      text = "${(range / 1000).toInt()}km",
-                      style = MaterialTheme.typography.bodyMedium,
-                      modifier = Modifier.padding(8.dp))
-                }
-
-                // Search bar to search by locality
-                Row {
-                  Text(
-                      text = "Locality : ",
-                      style =
-                          TextStyle(
-                              fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
-                  Spacer(modifier = Modifier.height(8.dp))
-                  // Dropdown to select the city
-                  LocalitySelectionDropdown(discoveryScreenViewModel)
-                }
-                Spacer(modifier = Modifier.height(12.dp))
-
-                // option to use current location with blue text and location icon
-                Row(
-                    modifier =
-                        Modifier.clickable { /*TODO SET SELECTEDLOCALITY TO CURRENT POSITION */}) {
-                      Icon(
-                          imageVector = Icons.Default.LocationOn,
-                          contentDescription = "Settings",
-                          tint = MaterialTheme.colorScheme.primary)
-                      Text(
-                          text = "Use my current location",
-                          style =
-                              TextStyle(
-                                  fontSize = 16.sp,
-                                  lineHeight = 24.sp,
-                                  fontWeight = FontWeight(500),
-                                  color = PrimaryBlue))
-                    }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                // Button to apply the range
-                ElevatedButton(
-                    onClick = {
-                      discoveryScreenViewModel.fetchClimbingActivities(
-                          range, discoveryScreenViewModel.selectedLocality.value.second)
-                      onDismissRequest()
-                    },
-                    modifier =
-                        Modifier.width(305.dp).height(48.dp).testTag("mapRangeSearchApplyButton"),
-                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
-                      Text(
-                          "Apply",
-                          style =
-                              TextStyle(
-                                  fontSize = 22.sp,
-                                  lineHeight = 28.sp,
-                                  fontWeight = FontWeight(400),
-                              ))
-                    }
-              }
-        }
-  }
-}
-
-@Composable
-fun ModalUpperSheet(isRangePopup: Boolean) {
-  if (isRangePopup) {
-    Surface(
-        modifier = Modifier.testTag("modalUpperSheet").height(200.dp),
-    ) {
-      Column(modifier = Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp)) {
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-          // put a small setting icon here with the settings built in icon
-          Icon(
-              imageVector = Icons.Default.Settings,
-              contentDescription = "Settings",
-              tint = MaterialTheme.colorScheme.secondary)
-          Text(
-              text = "   Modify your search settings   ",
-          )
-          Icon(
-              imageVector = Icons.Default.Settings,
-              contentDescription = "Settings",
-              tint = MaterialTheme.colorScheme.secondary)
-        }
-      }
-    }
-  }
-}
-
-// Dropdown to select the city
-@Composable
-fun LocalitySelectionDropdown(discoveryScreenViewModel: DiscoveryScreenViewModel) {
-  var expanded by remember { mutableStateOf(false) }
-  val localities = discoveryScreenViewModel.localities
-  var selectedLocality = discoveryScreenViewModel.selectedLocality.collectAsState().value
-
-  Box(modifier = Modifier.wrapContentSize().testTag("localitySelectionDropdown")) {
-    Text(
-        selectedLocality.first,
-        modifier =
-            Modifier.clickable(onClick = { expanded = true })
-                .testTag("localitySelectionDropdownButton"),
-        style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight(400), color = AccentGreen))
-    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-      localities.forEach { locality ->
-        DropdownMenuItem(
-            modifier = Modifier.testTag("localitySelectionDropdownItem"),
-            text = { Text(locality.first, color = AccentGreen) },
-            onClick = {
-              discoveryScreenViewModel.setSelectedLocality(locality)
-              expanded = false
-            })
-      }
-    }
-  }
-  Spacer(modifier = Modifier.height(8.dp))
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material3.ButtonDefaults
@@ -95,6 +96,9 @@ fun DiscoveryScreen(
     MapScreen()
     HeaderComposable(updatePopup = { isRangePopup = true })
   }
+
+  // Add the modal upper sheet
+  ModalUpperSheet(isRangePopup = isRangePopup)
 }
 
 @Composable
@@ -131,7 +135,7 @@ fun HeaderComposable(
                   }
 
                   Text(
-                      text = "Less than ${(range / 1000).toInt()} km",
+                      text = "Less than ${(range / 1000).toInt()} km around you",
                       style = MaterialTheme.typography.bodySmall)
                 }
               }
@@ -278,16 +282,16 @@ fun RangeSearchComposable(
               modifier = Modifier.fillMaxWidth().padding(16.dp)) {
                 // Select the City
                 Text(
-                    text = "Select the locality",
+                    text = "Locality :",
                     style =
                         TextStyle(
                             fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
                 Spacer(modifier = Modifier.height(8.dp))
                 // Dropdown to select the city
-                CitySelectionDropdown(discoveryScreenViewModel)
+                LocalitySelectionDropdown(discoveryScreenViewModel)
                 // Select the distance radius
                 Text(
-                    text = "Select the distance radius",
+                    text = "Distance radius :",
                     style =
                         TextStyle(
                             fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
@@ -343,7 +347,7 @@ fun RangeSearchComposable(
               horizontalAlignment = Alignment.CenterHorizontally,
               modifier = Modifier.fillMaxWidth().padding(16.dp)) {
                 Text(
-                    text = "Select the distance",
+                    text = "Select the distance radius",
                     style =
                         TextStyle(
                             fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
@@ -389,9 +393,35 @@ fun RangeSearchComposable(
   }
 }
 
+@Composable
+fun ModalUpperSheet(isRangePopup: Boolean) {
+  if (isRangePopup) {
+    Surface(
+        modifier = Modifier.testTag("modalUpperSheet").height(200.dp),
+    ) {
+      Column(modifier = Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+          // put a small setting icon here with the settings built in icon
+          Icon(
+              imageVector = Icons.Default.Settings,
+              contentDescription = "Settings",
+              tint = MaterialTheme.colorScheme.secondary)
+          Text(
+              text = "   Modify your search settings   ",
+          )
+          Icon(
+              imageVector = Icons.Default.Settings,
+              contentDescription = "Settings",
+              tint = MaterialTheme.colorScheme.secondary)
+        }
+      }
+    }
+  }
+}
+
 // Dropdown to select the city
 @Composable
-fun CitySelectionDropdown(discoveryScreenViewModel: DiscoveryScreenViewModel) {
+fun LocalitySelectionDropdown(discoveryScreenViewModel: DiscoveryScreenViewModel) {
   var expanded by remember { mutableStateOf(false) }
   val localities = discoveryScreenViewModel.localities
   var selectedLocality = discoveryScreenViewModel.selectedLocality.collectAsState().value

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
@@ -268,111 +268,122 @@ fun RangeSearchComposable(
   // list view search popup
   if (isRangePopup && screen == DiscoveryScreenType.LIST) {
 
-    ModalBottomSheet(onDismissRequest = onDismissRequest, modifier = Modifier.fillMaxWidth()) {
-      Column(
-          horizontalAlignment = Alignment.CenterHorizontally,
-          modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-            // Select the City
-            Text(
-                text = "Select the locality",
-                style =
-                    TextStyle(fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
-            Spacer(modifier = Modifier.height(8.dp))
-            // Dropdown to select the city
-            CitySelectionDropdown(discoveryScreenViewModel)
-            // Select the distance radius
-            Text(
-                text = "Select the distance radius",
-                style =
-                    TextStyle(fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
-            Spacer(modifier = Modifier.height(8.dp))
-            // Slider to select the range
-            Row {
-              Slider(
-                  value = range.toFloat(),
-                  onValueChange = {
-                    discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
-                  },
-                  valueRange = 0f..50000f,
-                  steps = 100,
-                  modifier = Modifier.width(305.dp))
-              Text(
-                  // put range in km
-                  text = "${(range / 1000).toInt()} km",
-                  style = MaterialTheme.typography.bodyMedium,
-                  modifier = Modifier.padding(8.dp))
-            }
-
-            // Button to apply the range
-            ElevatedButton(
-                onClick = {
-                  discoveryScreenViewModel.fetchClimbingActivities(
-                      range, discoveryScreenViewModel.selectedLocality.value.second)
-                  onDismissRequest()
-                },
-                modifier = Modifier.width(305.dp).height(48.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = Modifier.fillMaxWidth().testTag("searchOptions")) {
+          Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                // Select the City
+                Text(
+                    text = "Select the locality",
+                    style =
+                        TextStyle(
+                            fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+                Spacer(modifier = Modifier.height(8.dp))
+                // Dropdown to select the city
+                CitySelectionDropdown(discoveryScreenViewModel)
+                // Select the distance radius
+                Text(
+                    text = "Select the distance radius",
+                    style =
+                        TextStyle(
+                            fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+                Spacer(modifier = Modifier.height(8.dp))
+                // Slider to select the range
+                Row {
+                  Slider(
+                      value = range.toFloat(),
+                      onValueChange = {
+                        discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
+                      },
+                      valueRange = 0f..50000f,
+                      steps = 100,
+                      modifier = Modifier.width(305.dp).testTag("listSearchOptionsSlider"))
                   Text(
-                      "Search",
-                      style =
-                          TextStyle(
-                              fontSize = 22.sp,
-                              lineHeight = 28.sp,
-                              fontWeight = FontWeight(400),
-                          ))
+                      // put range in km
+                      text = "${(range / 1000).toInt()} km",
+                      style = MaterialTheme.typography.bodyMedium,
+                      modifier = Modifier.padding(8.dp))
                 }
-          }
-    }
+
+                // Button to apply the range
+                ElevatedButton(
+                    onClick = {
+                      discoveryScreenViewModel.fetchClimbingActivities(
+                          range, discoveryScreenViewModel.selectedLocality.value.second)
+                      onDismissRequest()
+                    },
+                    modifier =
+                        Modifier.width(305.dp)
+                            .height(48.dp)
+                            .testTag("listSearchOptionsApplyButton"),
+                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+                      Text(
+                          "Search",
+                          style =
+                              TextStyle(
+                                  fontSize = 22.sp,
+                                  lineHeight = 28.sp,
+                                  fontWeight = FontWeight(400),
+                              ))
+                    }
+              }
+        }
   }
 
   // map range search popup
   if (isRangePopup && screen == DiscoveryScreenType.MAP) {
-    ModalBottomSheet(onDismissRequest = onDismissRequest, modifier = Modifier.fillMaxWidth()) {
-      Column(
-          horizontalAlignment = Alignment.CenterHorizontally,
-          modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-            Text(
-                text = "Select the distance",
-                style =
-                    TextStyle(fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
-            Spacer(modifier = Modifier.height(8.dp))
-            // Slider to select the range
-            Row {
-              Slider(
-                  value = range.toFloat(),
-                  onValueChange = {
-                    discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
-                  },
-                  valueRange = 0f..50000f,
-                  steps = 100,
-                  modifier = Modifier.width(305.dp))
-              Text(
-                  // put range in km
-                  text = "${(range / 1000).toInt()} km",
-                  style = MaterialTheme.typography.bodyMedium,
-                  modifier = Modifier.padding(8.dp))
-            }
-
-            // Button to apply the range
-            ElevatedButton(
-                onClick = {
-                  discoveryScreenViewModel.fetchClimbingActivities(
-                      range, discoveryScreenViewModel.selectedLocality.value.second)
-                  onDismissRequest()
-                },
-                modifier = Modifier.width(305.dp).height(48.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = Modifier.fillMaxWidth().testTag("rangeSearch")) {
+          Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                Text(
+                    text = "Select the distance",
+                    style =
+                        TextStyle(
+                            fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+                Spacer(modifier = Modifier.height(8.dp))
+                // Slider to select the range
+                Row {
+                  Slider(
+                      value = range.toFloat(),
+                      onValueChange = {
+                        discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
+                      },
+                      valueRange = 0f..50000f,
+                      steps = 100,
+                      modifier = Modifier.width(305.dp).testTag("mapRangeSearchSlider"))
                   Text(
-                      "Apply",
-                      style =
-                          TextStyle(
-                              fontSize = 22.sp,
-                              lineHeight = 28.sp,
-                              fontWeight = FontWeight(400),
-                          ))
+                      // put range in km
+                      text = "${(range / 1000).toInt()} km",
+                      style = MaterialTheme.typography.bodyMedium,
+                      modifier = Modifier.padding(8.dp))
                 }
-          }
-    }
+
+                // Button to apply the range
+                ElevatedButton(
+                    onClick = {
+                      discoveryScreenViewModel.fetchClimbingActivities(
+                          range, discoveryScreenViewModel.selectedLocality.value.second)
+                      onDismissRequest()
+                    },
+                    modifier =
+                        Modifier.width(305.dp).height(48.dp).testTag("mapRangeSearchApplyButton"),
+                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+                      Text(
+                          "Apply",
+                          style =
+                              TextStyle(
+                                  fontSize = 22.sp,
+                                  lineHeight = 28.sp,
+                                  fontWeight = FontWeight(400),
+                              ))
+                    }
+              }
+        }
   }
 }
 
@@ -383,10 +394,12 @@ fun CitySelectionDropdown(discoveryScreenViewModel: DiscoveryScreenViewModel) {
   val localities = discoveryScreenViewModel.localities
   var selectedLocality = discoveryScreenViewModel.selectedLocality.collectAsState().value
 
-  Box(modifier = Modifier.wrapContentSize()) {
+  Box(modifier = Modifier.wrapContentSize().testTag("localitySelectionDropdown")) {
     Text(
         selectedLocality.first,
-        modifier = Modifier.clickable(onClick = { expanded = true }),
+        modifier =
+            Modifier.clickable(onClick = { expanded = true })
+                .testTag("localitySelectionDropdownButton"),
         style =
             TextStyle(
                 fontSize = 22.sp,

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
@@ -120,12 +120,14 @@ fun HeaderComposable(
                   Row {
                     Text(text = selectedLocality.first, style = MaterialTheme.typography.bodyMedium)
 
-                    IconButton(onClick = updatePopup, modifier = Modifier.size(24.dp)) {
-                      Icon(
-                          Icons.Outlined.KeyboardArrowDown,
-                          contentDescription = "Filter",
-                          modifier = Modifier.size(24.dp))
-                    }
+                    IconButton(
+                        onClick = updatePopup,
+                        modifier = Modifier.size(24.dp).testTag("listSearchOptionsEnableButton")) {
+                          Icon(
+                              Icons.Outlined.KeyboardArrowDown,
+                              contentDescription = "Filter",
+                              modifier = Modifier.size(24.dp))
+                        }
                   }
 
                   Text(
@@ -409,6 +411,7 @@ fun CitySelectionDropdown(discoveryScreenViewModel: DiscoveryScreenViewModel) {
     DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
       localities.forEach { locality ->
         DropdownMenuItem(
+            modifier = Modifier.testTag("localitySelectionDropdownItem"),
             text = { Text(locality.first, color = AccentGreen) },
             onClick = {
               discoveryScreenViewModel.setSelectedLocality(locality)

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
@@ -305,10 +306,10 @@ fun RangeSearchComposable(
                       },
                       valueRange = 0f..50000f,
                       steps = 100,
-                      modifier = Modifier.width(305.dp).testTag("listSearchOptionsSlider"))
+                      modifier = Modifier.width(300.dp).testTag("listSearchOptionsSlider"))
                   Text(
                       // put range in km
-                      text = "${(range / 1000).toInt()} km",
+                      text = "${(range / 1000).toInt()}km",
                       style = MaterialTheme.typography.bodyMedium,
                       modifier = Modifier.padding(8.dp))
                 }
@@ -351,7 +352,6 @@ fun RangeSearchComposable(
                     style =
                         TextStyle(
                             fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
-                Spacer(modifier = Modifier.height(8.dp))
                 // Slider to select the range
                 Row {
                   Slider(
@@ -361,13 +361,46 @@ fun RangeSearchComposable(
                       },
                       valueRange = 0f..50000f,
                       steps = 100,
-                      modifier = Modifier.width(305.dp).testTag("mapRangeSearchSlider"))
+                      modifier = Modifier.width(300.dp).testTag("mapRangeSearchSlider"))
                   Text(
                       // put range in km
-                      text = "${(range / 1000).toInt()} km",
+                      text = "${(range / 1000).toInt()}km",
                       style = MaterialTheme.typography.bodyMedium,
                       modifier = Modifier.padding(8.dp))
                 }
+
+                // Search bar to search by locality
+                Row {
+                  Text(
+                      text = "Locality : ",
+                      style =
+                          TextStyle(
+                              fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+                  Spacer(modifier = Modifier.height(8.dp))
+                  // Dropdown to select the city
+                  LocalitySelectionDropdown(discoveryScreenViewModel)
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // option to use current location with blue text and location icon
+                Row(
+                    modifier =
+                        Modifier.clickable { /*TODO SET SELECTEDLOCALITY TO CURRENT POSITION */}) {
+                      Icon(
+                          imageVector = Icons.Default.LocationOn,
+                          contentDescription = "Settings",
+                          tint = MaterialTheme.colorScheme.primary)
+                      Text(
+                          text = "Use my current location",
+                          style =
+                              TextStyle(
+                                  fontSize = 16.sp,
+                                  lineHeight = 24.sp,
+                                  fontWeight = FontWeight(500),
+                                  color = PrimaryBlue))
+                    }
+
+                Spacer(modifier = Modifier.height(12.dp))
 
                 // Button to apply the range
                 ElevatedButton(
@@ -432,12 +465,7 @@ fun LocalitySelectionDropdown(discoveryScreenViewModel: DiscoveryScreenViewModel
         modifier =
             Modifier.clickable(onClick = { expanded = true })
                 .testTag("localitySelectionDropdownButton"),
-        style =
-            TextStyle(
-                fontSize = 22.sp,
-                lineHeight = 28.sp,
-                fontWeight = FontWeight(400),
-                color = AccentGreen))
+        style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight(400), color = AccentGreen))
     DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
       localities.forEach { locality ->
         DropdownMenuItem(

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt
@@ -20,25 +20,34 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.lastaoutdoor.lasta.R
@@ -47,6 +56,7 @@ import com.lastaoutdoor.lasta.ui.components.SearchBarComponent
 import com.lastaoutdoor.lasta.ui.components.SeparatorComponent
 import com.lastaoutdoor.lasta.ui.navigation.LeafScreen
 import com.lastaoutdoor.lasta.ui.screen.map.MapScreen
+import com.lastaoutdoor.lasta.ui.theme.PrimaryBlue
 import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenType
 import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenViewModel
 
@@ -57,11 +67,23 @@ fun DiscoveryScreen(
 ) {
   val screen by discoveryScreenViewModel.screen.collectAsState()
 
+
+
+    var isRangePopup by rememberSaveable { mutableStateOf(false) }
+
+    RangeSearchComposable(
+        discoveryScreenViewModel = discoveryScreenViewModel,
+        isRangePopup = isRangePopup,
+        onDismissRequest = { isRangePopup = false })
+
+
   if (screen == DiscoveryScreenType.LIST) {
     LazyColumn(
         modifier =
-            Modifier.testTag("discoveryScreen").background(MaterialTheme.colorScheme.background)) {
-          item { HeaderComposable() }
+        Modifier
+            .testTag("discoveryScreen")
+            .background(MaterialTheme.colorScheme.background)) {
+          item { HeaderComposable(updatePopup = {isRangePopup = true}) }
 
           item {
             SeparatorComponent() // Add a separator between the header and the activities
@@ -71,30 +93,34 @@ fun DiscoveryScreen(
         }
   } else if (screen == DiscoveryScreenType.MAP) {
     MapScreen()
-    HeaderComposable()
+    HeaderComposable(updatePopup = {isRangePopup = true})
   }
 }
 
-@Preview
 @Composable
-fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltViewModel()) {
+fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltViewModel(), updatePopup: () -> Unit) {
   val screen by discoveryScreenViewModel.screen.collectAsState()
+    val range by discoveryScreenViewModel.range.collectAsState()
   val iconSize = 48.dp // Adjust icon size as needed
 
   Surface(
-      modifier = Modifier.fillMaxWidth().graphicsLayer { alpha = 0.9f },
+      modifier = Modifier
+          .fillMaxWidth()
+          .graphicsLayer { alpha = 0.9f },
       color = MaterialTheme.colorScheme.background,
       shadowElevation = 3.dp) {
         Column {
           // Location bar
           Row(
-              modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+              modifier = Modifier
+                  .fillMaxWidth()
+                  .padding(horizontal = 16.dp, vertical = 8.dp),
               verticalAlignment = Alignment.CenterVertically) {
                 Column {
                   Row {
                     Text(text = "Ecublens", style = MaterialTheme.typography.titleMedium)
 
-                    IconButton(onClick = { /*TODO*/}, modifier = Modifier.size(24.dp)) {
+                    IconButton(onClick = updatePopup, modifier = Modifier.size(24.dp)) {
                       Icon(
                           Icons.Outlined.KeyboardArrowDown,
                           contentDescription = "Filter",
@@ -102,13 +128,15 @@ fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltVi
                     }
                   }
 
-                  Text(text = "Less than 3 km", style = MaterialTheme.typography.bodySmall)
+                  Text(text = "Less than ${(range / 1000).toInt()} km", style = MaterialTheme.typography.bodySmall)
                 }
               }
 
           // Search bar with toggle buttons
           Row(
-              modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+              modifier = Modifier
+                  .fillMaxWidth()
+                  .padding(horizontal = 16.dp, vertical = 8.dp),
               verticalAlignment = Alignment.CenterVertically) {
                 SearchBarComponent(Modifier.weight(1f), onSearch = { /*TODO*/})
                 Spacer(modifier = Modifier.width(8.dp))
@@ -120,7 +148,9 @@ fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltVi
                 }
               }
           Row(
-              modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+              modifier = Modifier
+                  .fillMaxWidth()
+                  .padding(horizontal = 16.dp, vertical = 8.dp),
               verticalAlignment = Alignment.CenterVertically,
               horizontalArrangement = Arrangement.Center) {
                 DisplaySelection(
@@ -132,7 +162,9 @@ fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltVi
 
           if (screen == DiscoveryScreenType.LIST) {
             Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically) {
                   Text("Filtering by:", style = MaterialTheme.typography.bodyMedium)
                   Spacer(modifier = Modifier.width(8.dp))
@@ -141,7 +173,8 @@ fun HeaderComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltVi
                       style = MaterialTheme.typography.bodyMedium,
                       color = MaterialTheme.colorScheme.primary)
 
-                  IconButton(onClick = { /*TODO*/}, modifier = Modifier.size(24.dp)) {
+                  IconButton(onClick = { /*TODO*/
+                  }, modifier = Modifier.size(24.dp)) {
                     Icon(
                         Icons.Outlined.KeyboardArrowDown,
                         contentDescription = "Filter",
@@ -163,23 +196,27 @@ fun ActivitiesDisplay(
   for (a in activities) {
     Card(
         modifier =
-            Modifier.fillMaxWidth()
-                .wrapContentHeight()
-                .padding(vertical = 8.dp, horizontal = 16.dp)
-                .clickable(onClick = { navController.navigate(LeafScreen.MoreInfo.route) }),
+        Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(vertical = 8.dp, horizontal = 16.dp)
+            .clickable(onClick = { navController.navigate(LeafScreen.MoreInfo.route) }),
         shape = RoundedCornerShape(8.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
     ) {
       Column {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween) {
               Box(
                   modifier =
-                      Modifier.shadow(4.dp, RoundedCornerShape(30))
-                          .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(10.dp))
-                          .padding(PaddingValues(8.dp))) {
+                  Modifier
+                      .shadow(4.dp, RoundedCornerShape(30))
+                      .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(10.dp))
+                      .padding(PaddingValues(8.dp))) {
                     Text(
                         text = "Climbing",
                         style = MaterialTheme.typography.labelMedium,
@@ -198,7 +235,9 @@ fun ActivitiesDisplay(
 
         Spacer(modifier = Modifier.height(16.dp))
         Row(
-            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
             verticalAlignment = Alignment.CenterVertically) {
               Text(
                   text = a.locationName ?: "Unnamed Activity",
@@ -207,7 +246,9 @@ fun ActivitiesDisplay(
             }
         SeparatorComponent()
         Row(
-            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
             verticalAlignment = Alignment.CenterVertically) {
               Icon(
                   imageVector = Icons.Default.Star,
@@ -223,4 +264,130 @@ fun ActivitiesDisplay(
       }
     }
   }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RangeSearchComposable(discoveryScreenViewModel: DiscoveryScreenViewModel = hiltViewModel(), isRangePopup: Boolean, onDismissRequest: () -> Unit){
+    //create local variable to hold the current range whcih will then be sent as argument to the discoveryScreenViewModel.getActivities with the range
+    val range by discoveryScreenViewModel.range.collectAsState()
+    val screen by discoveryScreenViewModel.screen.collectAsState()
+
+
+    //list view search popup
+    if (isRangePopup && screen == DiscoveryScreenType.LIST) {
+        ModalBottomSheet(onDismissRequest = onDismissRequest, modifier = Modifier.fillMaxWidth()) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = "Select the distance radius",
+                    style = TextStyle(
+                        fontSize = 16.sp,
+                        lineHeight = 24.sp,
+                        fontWeight = FontWeight(500)
+                    ))
+                Spacer(modifier = Modifier.height(8.dp))
+                //Slider to select the range
+                Row {
+                    Slider(
+                        value = range.toFloat(),
+                        onValueChange = {  discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0)) },
+                        valueRange = 0f..50000f,
+                        steps = 100,
+                        modifier = Modifier.width(305.dp)
+                    )
+                    Text(
+                        //put range in km
+                        text = "${(range / 1000).toInt()} km",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(8.dp)
+                    )
+                }
+
+                //Button to apply the range
+                ElevatedButton(
+                    onClick = {
+                        discoveryScreenViewModel.setRange(range)
+                        discoveryScreenViewModel.fetchClimbingActivities(range)
+                        onDismissRequest()
+                    },
+                    modifier = Modifier
+                        .width(305.dp)
+                        .height(48.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+                    Text(
+                        "Search",
+                        style =
+                        TextStyle(
+                            fontSize = 22.sp,
+                            lineHeight = 28.sp,
+                            fontWeight = FontWeight(400),
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    //map range search popup
+    if (isRangePopup && screen == DiscoveryScreenType.MAP) {
+        ModalBottomSheet(onDismissRequest = onDismissRequest, modifier = Modifier.fillMaxWidth()) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = "Select the distance",
+                    style = TextStyle(
+                        fontSize = 16.sp,
+                        lineHeight = 24.sp,
+                        fontWeight = FontWeight(500)
+                ))
+                Spacer(modifier = Modifier.height(8.dp))
+                //Slider to select the range
+                Row {
+                    Slider(
+                        value = range.toFloat(),
+                        onValueChange = { discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0)) },
+                        valueRange = 0f..50000f,
+                        steps = 100,
+                        modifier = Modifier.width(305.dp)
+                    )
+                    Text(
+                        //put range in km
+                        text = "${(range / 1000).toInt()} km",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(8.dp)
+                    )
+                }
+
+                //Button to apply the range
+                ElevatedButton(
+                    onClick = {
+                        //discoveryScreenViewModel.getActivities(range)
+                        onDismissRequest()
+                    },
+                    modifier = Modifier
+                        .width(305.dp)
+                        .height(48.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+                    Text(
+                        "Apply",
+                        style =
+                        TextStyle(
+                            fontSize = 22.sp,
+                            lineHeight = 28.sp,
+                            fontWeight = FontWeight(400),
+                        )
+                    )
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/components/LocalitySelectionDropdown.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/components/LocalitySelectionDropdown.kt
@@ -1,0 +1,53 @@
+package com.lastaoutdoor.lasta.ui.screen.discovery.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.lastaoutdoor.lasta.ui.theme.AccentGreen
+import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenViewModel
+
+// Dropdown to select the city
+@Composable
+fun LocalitySelectionDropdown(discoveryScreenViewModel: DiscoveryScreenViewModel) {
+  var expanded by remember { mutableStateOf(false) }
+  val localities = discoveryScreenViewModel.localities
+  var selectedLocality = discoveryScreenViewModel.selectedLocality.collectAsState().value
+
+  Box(modifier = Modifier.wrapContentSize().testTag("localitySelectionDropdown")) {
+    Text(
+        selectedLocality.first,
+        modifier =
+            Modifier.clickable(onClick = { expanded = true })
+                .testTag("localitySelectionDropdownButton"),
+        style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight(400), color = AccentGreen))
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+      localities.forEach { locality ->
+        DropdownMenuItem(
+            modifier = Modifier.testTag("localitySelectionDropdownItem"),
+            text = { Text(locality.first, color = AccentGreen) },
+            onClick = {
+              discoveryScreenViewModel.setSelectedLocality(locality)
+              expanded = false
+            })
+      }
+    }
+  }
+  Spacer(modifier = Modifier.height(8.dp))
+}

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/components/ModalUpperSheet.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/components/ModalUpperSheet.kt
@@ -1,0 +1,45 @@
+package com.lastaoutdoor.lasta.ui.screen.discovery.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ModalUpperSheet(isRangePopup: Boolean) {
+  if (isRangePopup) {
+    Surface(
+        modifier = Modifier.testTag("modalUpperSheet").height(200.dp),
+    ) {
+      Column(modifier = Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+          // put a small setting icon here with the settings built in icon
+          Icon(
+              imageVector = Icons.Default.Settings,
+              contentDescription = "Settings",
+              tint = MaterialTheme.colorScheme.secondary)
+          Text(
+              text = "   Modify your search settings   ",
+          )
+          Icon(
+              imageVector = Icons.Default.Settings,
+              contentDescription = "Settings",
+              tint = MaterialTheme.colorScheme.secondary)
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/components/RangeSearchComposable.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/components/RangeSearchComposable.kt
@@ -1,0 +1,200 @@
+package com.lastaoutdoor.lasta.ui.screen.discovery.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.lastaoutdoor.lasta.ui.theme.PrimaryBlue
+import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenType
+import com.lastaoutdoor.lasta.viewmodel.DiscoveryScreenViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RangeSearchComposable(
+    discoveryScreenViewModel: DiscoveryScreenViewModel = hiltViewModel(),
+    isRangePopup: Boolean,
+    onDismissRequest: () -> Unit
+) {
+  // create local variable to hold the current range whcih will then be sent as argument to the
+  // discoveryScreenViewModel.getActivities with the range
+  val range by discoveryScreenViewModel.range.collectAsState()
+  val screen by discoveryScreenViewModel.screen.collectAsState()
+
+  // list view search popup
+  if (isRangePopup && screen == DiscoveryScreenType.LIST) {
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = Modifier.fillMaxWidth().testTag("searchOptions")) {
+          Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                // Select the City
+                Text(
+                    text = "Locality :",
+                    style =
+                        TextStyle(
+                            fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+                Spacer(modifier = Modifier.height(8.dp))
+                // Dropdown to select the city
+                LocalitySelectionDropdown(discoveryScreenViewModel)
+                // Select the distance radius
+                Text(
+                    text = "Distance radius :",
+                    style =
+                        TextStyle(
+                            fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+                Spacer(modifier = Modifier.height(8.dp))
+                // Slider to select the range
+                Row {
+                  Slider(
+                      value = range.toFloat(),
+                      onValueChange = {
+                        discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
+                      },
+                      valueRange = 0f..50000f,
+                      steps = 100,
+                      modifier = Modifier.width(300.dp).testTag("listSearchOptionsSlider"))
+                  Text(
+                      // put range in km
+                      text = "${(range / 1000).toInt()}km",
+                      style = MaterialTheme.typography.bodyMedium,
+                      modifier = Modifier.padding(8.dp))
+                }
+
+                // Button to apply the range
+                ElevatedButton(
+                    onClick = {
+                      discoveryScreenViewModel.fetchClimbingActivities(
+                          range, discoveryScreenViewModel.selectedLocality.value.second)
+                      onDismissRequest()
+                    },
+                    modifier =
+                        Modifier.width(305.dp)
+                            .height(48.dp)
+                            .testTag("listSearchOptionsApplyButton"),
+                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+                      Text(
+                          "Search",
+                          style =
+                              TextStyle(
+                                  fontSize = 22.sp,
+                                  lineHeight = 28.sp,
+                                  fontWeight = FontWeight(400),
+                              ))
+                    }
+              }
+        }
+  }
+
+  // map range search popup
+  if (isRangePopup && screen == DiscoveryScreenType.MAP) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = Modifier.fillMaxWidth().testTag("rangeSearch")) {
+          Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                Text(
+                    text = "Select the distance radius",
+                    style =
+                        TextStyle(
+                            fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+                // Slider to select the range
+                Row {
+                  Slider(
+                      value = range.toFloat(),
+                      onValueChange = {
+                        discoveryScreenViewModel.setRange(it.toDouble().coerceIn(1000.0, 50000.0))
+                      },
+                      valueRange = 0f..50000f,
+                      steps = 100,
+                      modifier = Modifier.width(300.dp).testTag("mapRangeSearchSlider"))
+                  Text(
+                      // put range in km
+                      text = "${(range / 1000).toInt()}km",
+                      style = MaterialTheme.typography.bodyMedium,
+                      modifier = Modifier.padding(8.dp))
+                }
+
+                // Search bar to search by locality
+                Row {
+                  Text(
+                      text = "Locality : ",
+                      style =
+                          TextStyle(
+                              fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight(500)))
+                  Spacer(modifier = Modifier.height(8.dp))
+                  // Dropdown to select the city
+                  LocalitySelectionDropdown(discoveryScreenViewModel)
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // option to use current location with blue text and location icon
+                Row(
+                    modifier =
+                        Modifier.clickable { /*TODO SET SELECTEDLOCALITY TO CURRENT POSITION */}) {
+                      Icon(
+                          imageVector = Icons.Default.LocationOn,
+                          contentDescription = "Settings",
+                          tint = MaterialTheme.colorScheme.primary)
+                      Text(
+                          text = "Use my current location",
+                          style =
+                              TextStyle(
+                                  fontSize = 16.sp,
+                                  lineHeight = 24.sp,
+                                  fontWeight = FontWeight(500),
+                                  color = PrimaryBlue))
+                    }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Button to apply the range
+                ElevatedButton(
+                    onClick = {
+                      discoveryScreenViewModel.fetchClimbingActivities(
+                          range, discoveryScreenViewModel.selectedLocality.value.second)
+                      onDismissRequest()
+                    },
+                    modifier =
+                        Modifier.width(305.dp).height(48.dp).testTag("mapRangeSearchApplyButton"),
+                    colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+                      Text(
+                          "Apply",
+                          style =
+                              TextStyle(
+                                  fontSize = 22.sp,
+                                  lineHeight = 28.sp,
+                                  fontWeight = FontWeight(400),
+                              ))
+                    }
+              }
+        }
+  }
+}

--- a/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/DiscoveryScreenViewModel.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/DiscoveryScreenViewModel.kt
@@ -33,6 +33,18 @@ constructor(private val repository: OutdoorActivityRepository) : ViewModel() {
     private val _range = MutableStateFlow(10000.0)
     val range: StateFlow<Double> = _range
 
+    // List of localities with their LatLng coordinates
+    val localities = listOf(
+        "Ecublens" to LatLng(46.519962, 6.633597),
+        "Geneva" to LatLng(46.2043907, 6.1431577),
+        "Payerne" to LatLng(46.834190, 6.928969),
+        "Matterhorn" to LatLng(45.980537, 7.641618)
+    )
+    // Selected locality
+    private val _selectedLocality = MutableStateFlow(localities[0])
+    val selectedLocality: StateFlow<Pair<String, LatLng>> = _selectedLocality
+
+
   init {
     fetchClimbingActivities()
   }
@@ -73,7 +85,13 @@ constructor(private val repository: OutdoorActivityRepository) : ViewModel() {
     _screen.value = screen
   }
 
+    // Set the range for the activities
     fun setRange(range: Double) {
         _range.value = range
+    }
+
+    // Set the selected locality
+    fun setSelectedLocality(locality: Pair<String, LatLng>) {
+        _selectedLocality.value = locality
     }
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/DiscoveryScreenViewModel.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/DiscoveryScreenViewModel.kt
@@ -7,9 +7,9 @@ import com.lastaoutdoor.lasta.data.model.activity.OutdoorActivity
 import com.lastaoutdoor.lasta.data.model.api.Node
 import com.lastaoutdoor.lasta.repository.OutdoorActivityRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
 
 enum class DiscoveryScreenType {
   LIST,
@@ -30,11 +30,13 @@ constructor(private val repository: OutdoorActivityRepository) : ViewModel() {
   private val _screen = MutableStateFlow(DiscoveryScreenType.LIST)
   val screen: StateFlow<DiscoveryScreenType> = _screen
 
+    private val _range = MutableStateFlow(10000.0)
+    val range: StateFlow<Double> = _range
+
   init {
     fetchClimbingActivities()
   }
-
-  private fun fetchClimbingActivities(
+    fun fetchClimbingActivities(
       rad: Double = 10000.0,
       centerLocation: LatLng = LatLng(46.519962, 6.633597)
   ) {
@@ -65,7 +67,13 @@ constructor(private val repository: OutdoorActivityRepository) : ViewModel() {
     }
   }
 
+
+
   fun setScreen(screen: DiscoveryScreenType) {
     _screen.value = screen
   }
+
+    fun setRange(range: Double) {
+        _range.value = range
+    }
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/DiscoveryScreenViewModel.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/DiscoveryScreenViewModel.kt
@@ -7,9 +7,9 @@ import com.lastaoutdoor.lasta.data.model.activity.OutdoorActivity
 import com.lastaoutdoor.lasta.data.model.api.Node
 import com.lastaoutdoor.lasta.repository.OutdoorActivityRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import javax.inject.Inject
 
 enum class DiscoveryScreenType {
   LIST,
@@ -30,25 +30,25 @@ constructor(private val repository: OutdoorActivityRepository) : ViewModel() {
   private val _screen = MutableStateFlow(DiscoveryScreenType.LIST)
   val screen: StateFlow<DiscoveryScreenType> = _screen
 
-    private val _range = MutableStateFlow(10000.0)
-    val range: StateFlow<Double> = _range
+  private val _range = MutableStateFlow(10000.0)
+  val range: StateFlow<Double> = _range
 
-    // List of localities with their LatLng coordinates
-    val localities = listOf(
-        "Ecublens" to LatLng(46.519962, 6.633597),
-        "Geneva" to LatLng(46.2043907, 6.1431577),
-        "Payerne" to LatLng(46.834190, 6.928969),
-        "Matterhorn" to LatLng(45.980537, 7.641618)
-    )
-    // Selected locality
-    private val _selectedLocality = MutableStateFlow(localities[0])
-    val selectedLocality: StateFlow<Pair<String, LatLng>> = _selectedLocality
-
+  // List of localities with their LatLng coordinates
+  val localities =
+      listOf(
+          "Ecublens" to LatLng(46.519962, 6.633597),
+          "Geneva" to LatLng(46.2043907, 6.1431577),
+          "Payerne" to LatLng(46.834190, 6.928969),
+          "Matterhorn" to LatLng(45.980537, 7.641618))
+  // Selected locality
+  private val _selectedLocality = MutableStateFlow(localities[0])
+  val selectedLocality: StateFlow<Pair<String, LatLng>> = _selectedLocality
 
   init {
     fetchClimbingActivities()
   }
-    fun fetchClimbingActivities(
+
+  fun fetchClimbingActivities(
       rad: Double = 10000.0,
       centerLocation: LatLng = LatLng(46.519962, 6.633597)
   ) {
@@ -79,19 +79,17 @@ constructor(private val repository: OutdoorActivityRepository) : ViewModel() {
     }
   }
 
-
-
   fun setScreen(screen: DiscoveryScreenType) {
     _screen.value = screen
   }
 
-    // Set the range for the activities
-    fun setRange(range: Double) {
-        _range.value = range
-    }
+  // Set the range for the activities
+  fun setRange(range: Double) {
+    _range.value = range
+  }
 
-    // Set the selected locality
-    fun setSelectedLocality(locality: Pair<String, LatLng>) {
-        _selectedLocality.value = locality
-    }
+  // Set the selected locality
+  fun setSelectedLocality(locality: Pair<String, LatLng>) {
+    _selectedLocality.value = locality
+  }
 }


### PR DESCRIPTION
# PR

## Overview
This PR features search options allowing the user to direct his/her activity searching, both for list mode and map mode. 


https://github.com/LASTA-OUTDOOR/lasta/assets/91049597/6960a5c2-8378-4b70-907a-8bf3397e1804 

<img width="200" alt="map search options" src="https://github.com/LASTA-OUTDOOR/lasta/assets/91049597/4f4da06c-ccd5-421c-ab24-1511b697a016">
<img width="198" alt="map search options light" src="https://github.com/LASTA-OUTDOOR/lasta/assets/91049597/7faed1f4-3e5c-4950-9138-b21c99056c98">




## Changes
Added a popping menu triggered by clicking on the down-faced arrow next to the Locality displaying, allowing to choose from different localities, as well as choosing the range inside which the activities will be shown. By clicking on the "Apply" button, the changes are applied and a subsequent call to the API (and when finished to the database too) is made, resulting in a display of the activities found. The new saved search settings are then displayed on the top left of the screen. 
### Files changed
- `app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreen.kt` : Added components that display the search options and call the functions from `DiscoveryScreenViewModel` with the updated parameters.
- `app/src/main/java/com/lastaoutdoor/lasta/viewmodel/DiscoveryScreenViewModel.kt` : Added variables and setters to store range and position settings.
- `app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discovery/DiscoveryScreenTest.kt` : Added android tests to check for the components correct functioning.

## What's next
Next steps would be to 
- Implement more options in the menu
- Finish implementing the visual searching on the map mode
- Link with database when implemented

## Notes
The search options for map mode are not yet linked with the map view model because it is currently under changes and will be working differently.