### PR TITLE
Made the More Info screen responsive, commented and tested it

### DIFF
--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.lastaoutdoor.lasta.di.AppModule
@@ -32,8 +33,24 @@ class MoreInfoScreenTest {
     }
   }
 
+  // Test that the top bar is displayed
   @Test
   fun topBar_isDisplayed() {
-    composeRule.onNodeWithTag("Top Bar").assertIsDisplayed()
+    composeRule.onNodeWithTag("MoreInfoTopBar").assertIsDisplayed()
+  }
+
+  // Test that the more info screen is displayed
+  @Test
+  fun moreInfoComposable_isDisplayed() {
+    // Check that the more info screen is displayed correctly
+    composeRule.onNodeWithTag("MoreInfoComposable").assertIsDisplayed()
+    // Check that start button is displayed
+    composeRule.onNodeWithTag("MoreInfoStartButton").assertIsDisplayed()
+    composeRule.onNodeWithTag("MoreInfoStartButton").performClick()
+    // Check that middle zone is displayed
+    composeRule.onNodeWithTag("MoreInfoMiddleZone").assertIsDisplayed()
+    // Check that activity title zone is displayed
+    composeRule.onNodeWithTag("MoreInfoActivityTitleZone").assertIsDisplayed()
+    composeRule.onNodeWithTag("MoreInfoActivityTypeComposable").assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -37,51 +37,56 @@ import com.lastaoutdoor.lasta.ui.theme.PrimaryBlue
 import com.lastaoutdoor.lasta.ui.theme.YellowDifficulty
 import com.lastaoutdoor.lasta.viewmodel.MoreInfoScreenViewModel
 
+// MoreInfoScreen : displays all the information of an activity
 @Composable
 fun MoreInfoScreen(navController: NavController, moreInfoScreenViewModel: MoreInfoScreenViewModel) {
-    Column(modifier = Modifier.fillMaxSize()) {
-        LazyColumn(modifier = Modifier.weight(1f).padding(8.dp)) {
-            item { Spacer(modifier = Modifier.height(15.dp)) }
-            item { TopBar(navController) }
-            item { ActivityTitleZone(moreInfoScreenViewModel) }
-            item { MiddleZone(moreInfoScreenViewModel) }
-        }
-        StartButton()
+  Column(modifier = Modifier.fillMaxSize().testTag("MoreInfoComposable")) {
+    LazyColumn(modifier = Modifier.weight(1f).padding(8.dp)) {
+      item { Spacer(modifier = Modifier.height(15.dp)) }
+      item { TopBar(navController) }
+      item { ActivityTitleZone(moreInfoScreenViewModel) }
+      item { MiddleZone(moreInfoScreenViewModel) }
     }
+    StartButton()
+  }
 }
 
+// Start button : once clicked, the activity tracking starts
 @Composable
 fun StartButton() {
-    Row(
-        modifier = Modifier.fillMaxWidth().testTag("Start button"),
-        horizontalArrangement = Arrangement.Center) {
+  Row(
+      modifier = Modifier.fillMaxWidth().testTag("MoreInfoStartButton"),
+      horizontalArrangement = Arrangement.Center) {
         ElevatedButton(
             onClick = {
-                /** TODO : Start Activity */
+              /** TODO : Start Activity */
             },
             modifier = Modifier.fillMaxWidth(0.8f).height(48.dp), // takes up 80% of the width
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
-            Text(
-                LocalContext.current.getString(R.string.start),
-                style =
-                TextStyle(
-                    fontSize = 22.sp,
-                    lineHeight = 28.sp,
-                    fontWeight = FontWeight(400),
-                ))
-        }
-    }
+              Text(
+                  LocalContext.current.getString(R.string.start),
+                  style =
+                      TextStyle(
+                          fontSize = 22.sp,
+                          lineHeight = 28.sp,
+                          fontWeight = FontWeight(400),
+                      ))
+            }
+      }
 }
 
+// Displays the difficulty and rating of the activity on the left and a button to view the activity
+// on the map on the right
 @Composable
 fun MiddleZone(moreInfoScreenViewModel: MoreInfoScreenViewModel) {
-    Row(modifier = Modifier.fillMaxWidth()) {
-        DiffAndRating(moreInfoScreenViewModel)
-        Spacer(modifier = Modifier.weight(1f)) // takes up remaining space
-        ViewOnMapButton()
-    }
+  Row(modifier = Modifier.fillMaxWidth().testTag("MoreInfoMiddleZone")) {
+    DiffAndRating(moreInfoScreenViewModel)
+    Spacer(modifier = Modifier.weight(1f)) // takes up remaining space
+    ViewOnMapButton()
+  }
 }
 
+// Button to view the activity on the map
 @Composable
 fun ViewOnMapButton() {
   Column(modifier = Modifier.padding(vertical = 25.dp), horizontalAlignment = Alignment.End) {
@@ -105,6 +110,7 @@ fun ViewOnMapButton() {
   }
 }
 
+// Displays the difficulty and rating of the activity
 @Composable
 fun DiffAndRating(moreInfoScreenViewModel: MoreInfoScreenViewModel) {
   Column(modifier = Modifier.padding(vertical = 5.dp)) {
@@ -117,6 +123,7 @@ fun DiffAndRating(moreInfoScreenViewModel: MoreInfoScreenViewModel) {
   }
 }
 
+// Displays the rating of the activity
 @Composable
 fun RatingDisplay(rating: Double) {
   Row(modifier = Modifier.padding(vertical = 30.dp)) {
@@ -138,6 +145,7 @@ fun RatingDisplay(rating: Double) {
   }
 }
 
+// Displays the difficulty of the activity
 @Composable
 fun ElevatedDifficultyDisplay(diff: String) {
   ElevatedButton(
@@ -161,15 +169,16 @@ fun ElevatedDifficultyDisplay(diff: String) {
 // Top Bar that displays the four clickable logos with distinct usages
 @Composable
 fun TopBar(navController: NavController) {
-    Row(modifier = Modifier.fillMaxWidth().testTag("Top Bar")) {
-        TopBarLogo(R.drawable.arrow_back) { navController.navigateUp() }
-        Spacer(modifier = Modifier.weight(1f)) // takes up remaining space
-        TopBarLogo(R.drawable.download_button) {}
-        TopBarLogo(R.drawable.share) {}
-        TopBarLogo(R.drawable.favourite) {}
-    }
+  Row(modifier = Modifier.fillMaxWidth().testTag("MoreInfoTopBar")) {
+    TopBarLogo(R.drawable.arrow_back) { navController.navigateUp() }
+    Spacer(modifier = Modifier.weight(1f)) // takes up remaining space
+    TopBarLogo(R.drawable.download_button) {}
+    TopBarLogo(R.drawable.share) {}
+    TopBarLogo(R.drawable.favourite) {}
+  }
 }
 
+// Logo of the top bar
 @Composable
 fun TopBarLogo(logoPainterId: Int, f: () -> Unit) {
   IconButton(onClick = { f() }) {
@@ -180,15 +189,17 @@ fun TopBarLogo(logoPainterId: Int, f: () -> Unit) {
   }
 }
 
+// Displays the title of the activity, its type and its duration
 @Composable
 fun ActivityTitleZone(moreInfoScreenViewModel: MoreInfoScreenViewModel) {
   Row { ElevatedActivityType(moreInfoScreenViewModel) }
-  Row {
+  Row (modifier = Modifier.testTag("MoreInfoActivityTitleZone"))  {
     ActivityPicture()
     ActivityTitleText(moreInfoScreenViewModel)
   }
 }
 
+// Displays the picture of the activity
 @Composable
 fun ActivityPicture() {
   Column {
@@ -223,7 +234,7 @@ fun ElevatedActivityType(moreInfoScreenViewModel: MoreInfoScreenViewModel) {
   ElevatedButton(
       onClick = {},
       contentPadding = PaddingValues(all = 3.dp),
-      modifier = Modifier.padding(3.dp).width(64.dp).height(20.dp),
+      modifier = Modifier.padding(3.dp).width(64.dp).height(20.dp).testTag("MoreInfoActivityTypeComposable"),
       colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
         Text(
             text =

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -52,25 +52,25 @@ fun MoreInfoScreen(navController: NavController, moreInfoScreenViewModel: MoreIn
 
 @Composable
 fun StartButton() {
-  Row(
-      modifier = Modifier.fillMaxWidth().testTag("Start button"),
-      horizontalArrangement = Arrangement.Center) {
+    Row(
+        modifier = Modifier.fillMaxWidth().testTag("Start button"),
+        horizontalArrangement = Arrangement.Center) {
         ElevatedButton(
             onClick = {
-              /** TODO : Start Activity */
+                /** TODO : Start Activity */
             },
-            modifier = Modifier.width(305.dp).height(48.dp),
+            modifier = Modifier.fillMaxWidth(0.8f).height(48.dp), // takes up 80% of the width
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
-              Text(
-                  LocalContext.current.getString(R.string.start),
-                  style =
-                      TextStyle(
-                          fontSize = 22.sp,
-                          lineHeight = 28.sp,
-                          fontWeight = FontWeight(400),
-                      ))
-            }
-      }
+            Text(
+                LocalContext.current.getString(R.string.start),
+                style =
+                TextStyle(
+                    fontSize = 22.sp,
+                    lineHeight = 28.sp,
+                    fontWeight = FontWeight(400),
+                ))
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -38,19 +39,15 @@ import com.lastaoutdoor.lasta.viewmodel.MoreInfoScreenViewModel
 
 @Composable
 fun MoreInfoScreen(navController: NavController, moreInfoScreenViewModel: MoreInfoScreenViewModel) {
-  LazyColumn(modifier = Modifier.padding(8.dp)) {
-    item { Spacer(modifier = Modifier.height(15.dp)) }
-    // contains the top icon buttons
-    item { TopBar(navController) }
-    // displays activity title and duration
-    item { ActivityTitleZone(moreInfoScreenViewModel) }
-    // displays activity difficulty, ration and view on map button
-    item { MiddleZone(moreInfoScreenViewModel) }
-    // filled with a spacer for the moment but will contain address + community
-    item { Spacer(modifier = Modifier.height(350.dp)) }
-    // Bottom start activity button
-    item { StartButton() }
-  }
+    Column(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(modifier = Modifier.weight(1f).padding(8.dp)) {
+            item { Spacer(modifier = Modifier.height(15.dp)) }
+            item { TopBar(navController) }
+            item { ActivityTitleZone(moreInfoScreenViewModel) }
+            item { MiddleZone(moreInfoScreenViewModel) }
+        }
+        StartButton()
+    }
 }
 
 @Composable
@@ -78,11 +75,11 @@ fun StartButton() {
 
 @Composable
 fun MiddleZone(moreInfoScreenViewModel: MoreInfoScreenViewModel) {
-  Row {
-    DiffAndRating(moreInfoScreenViewModel)
-    Spacer(Modifier.width(170.dp))
-    ViewOnMapButton()
-  }
+    Row(modifier = Modifier.fillMaxWidth()) {
+        DiffAndRating(moreInfoScreenViewModel)
+        Spacer(modifier = Modifier.weight(1f)) // takes up remaining space
+        ViewOnMapButton()
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -161,13 +161,13 @@ fun ElevatedDifficultyDisplay(diff: String) {
 // Top Bar that displays the four clickable logos with distinct usages
 @Composable
 fun TopBar(navController: NavController) {
-  Row(modifier = Modifier.fillMaxWidth().testTag("Top Bar")) {
-    TopBarLogo(R.drawable.arrow_back) { navController.navigateUp() }
-    Spacer(modifier = Modifier.width(180.dp))
-    TopBarLogo(R.drawable.download_button) {}
-    TopBarLogo(R.drawable.share) {}
-    TopBarLogo(R.drawable.favourite) {}
-  }
+    Row(modifier = Modifier.fillMaxWidth().testTag("Top Bar")) {
+        TopBarLogo(R.drawable.arrow_back) { navController.navigateUp() }
+        Spacer(modifier = Modifier.weight(1f)) // takes up remaining space
+        TopBarLogo(R.drawable.download_button) {}
+        TopBarLogo(R.drawable.share) {}
+        TopBarLogo(R.drawable.favourite) {}
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -193,7 +193,7 @@ fun TopBarLogo(logoPainterId: Int, f: () -> Unit) {
 @Composable
 fun ActivityTitleZone(moreInfoScreenViewModel: MoreInfoScreenViewModel) {
   Row { ElevatedActivityType(moreInfoScreenViewModel) }
-  Row (modifier = Modifier.testTag("MoreInfoActivityTitleZone"))  {
+  Row(modifier = Modifier.testTag("MoreInfoActivityTitleZone")) {
     ActivityPicture()
     ActivityTitleText(moreInfoScreenViewModel)
   }
@@ -234,7 +234,11 @@ fun ElevatedActivityType(moreInfoScreenViewModel: MoreInfoScreenViewModel) {
   ElevatedButton(
       onClick = {},
       contentPadding = PaddingValues(all = 3.dp),
-      modifier = Modifier.padding(3.dp).width(64.dp).height(20.dp).testTag("MoreInfoActivityTypeComposable"),
+      modifier =
+          Modifier.padding(3.dp)
+              .width(64.dp)
+              .height(20.dp)
+              .testTag("MoreInfoActivityTypeComposable"),
       colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
         Text(
             text =


### PR DESCRIPTION
# PR
## Changes
This PR changes the structural implementation of the more info screen. Its UI is no longer is hard coded and is now relative to the screen size and orientation. The start button is now in a Column with the rest in a LazyColumn so that the button appears at all time at the bottom, while preserving correct visibility. The whole more info screen is now tested as well.
Also added comments everywhere in the more info screen.

<img width="200" alt="vertical_more_info" src="https://github.com/LASTA-OUTDOOR/lasta/assets/91049597/1fffd06e-73c7-4745-b2f4-56604d9e20b8">
<img width="400" alt="horizontal_more_info" src="https://github.com/LASTA-OUTDOOR/lasta/assets/91049597/e3a433c3-51c1-40dd-a998-db978fa6f2f8">


https://github.com/LASTA-OUTDOOR/lasta/assets/91049597/5b74fda8-257f-45e6-a6ba-f91bee46aeca

### Files Changed
- `app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt`
- `app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt`

## What's next
- Implement the remaining informations (such as itinerary) to be shown in the more info from database (related to tracking epic -> Milestone 3)
- Maybe un-implement the horizontal mode for Lasta, which is for now supported here (but not in a few parts of the code like the map which is looking awful (while still working technically))


