### PR TITLE
Made the weather report relative to the currently displayed activity's location 

### DIFF
--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discover/DiscoveryScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discover/DiscoveryScreenTest.kt
@@ -120,7 +120,8 @@ class DiscoverScreenTest {
             favorites = emptyList(),
             changeActivityToDisplay = {},
             flipFavorite = {},
-            navigateToMoreInfo = {})
+            navigateToMoreInfo = {},
+            changeWeatherTarget = {})
       }
     }
 
@@ -184,7 +185,8 @@ class DiscoverScreenTest {
             selectedItinerary = null,
             orderingBy = OrderingBy.RATING,
             updateOrderingBy = {},
-            markerList = emptyList()) {}
+            markerList = emptyList(),
+            changeWeatherTarget = {}) {}
       }
     }
 
@@ -280,7 +282,8 @@ class DiscoverScreenTest {
             selectedItinerary = null,
             orderingBy = OrderingBy.DISTANCEASCENDING,
             updateOrderingBy = {},
-            markerList = emptyList()) {}
+            markerList = emptyList(),
+            changeWeatherTarget = {}) {}
       }
     }
 
@@ -348,7 +351,8 @@ class DiscoverScreenTest {
             selectedItinerary = null,
             orderingBy = OrderingBy.DIFFICULTYASCENDING,
             updateOrderingBy = {},
-            markerList = emptyList()) {}
+            markerList = emptyList(),
+            changeWeatherTarget = {}) {}
       }
     }
     composeRule.onNodeWithTag("sortingTextValue").assertIsDisplayed()
@@ -406,7 +410,8 @@ class DiscoverScreenTest {
             selectedItinerary = null,
             orderingBy = OrderingBy.DIFFICULTYDESCENDING,
             updateOrderingBy = {},
-            markerList = emptyList()) {}
+            markerList = emptyList(),
+            changeWeatherTarget = {}) {}
       }
     }
     composeRule.onNodeWithTag("sortingTextValue").assertIsDisplayed()
@@ -464,7 +469,8 @@ class DiscoverScreenTest {
             selectedItinerary = null,
             orderingBy = OrderingBy.POPULARITY,
             updateOrderingBy = {},
-            markerList = emptyList()) {}
+            markerList = emptyList(),
+            changeWeatherTarget = {}) {}
       }
     }
     composeRule.onNodeWithTag("sortingTextValue").assertIsDisplayed()
@@ -522,7 +528,8 @@ class DiscoverScreenTest {
             selectedItinerary = null,
             orderingBy = OrderingBy.DISTANCEDESCENDING,
             updateOrderingBy = {},
-            markerList = emptyList()) {}
+            markerList = emptyList(),
+            changeWeatherTarget = {}) {}
       }
     }
     composeRule.onNodeWithTag("sortingTextValue").assertIsDisplayed()

--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discover/DiscoveryScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/discover/DiscoveryScreenTest.kt
@@ -127,7 +127,8 @@ class DiscoverScreenTest {
             selectedItinerary = null,
             orderingBy = OrderingBy.RATING,
             updateOrderingBy = {},
-            markerList = emptyList()) {}
+            markerList = emptyList(),
+            changeWeatherTarget = {}) {}
       }
     }
     composeRule.onNodeWithTag("LoadingBarDiscover").assertIsDisplayed()

--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/favorites/FavoritesScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/favorites/FavoritesScreenTest.kt
@@ -52,7 +52,8 @@ class FavoritesScreenTest {
             centerPoint = LatLng(46.519962, 6.633597),
             favorites = listOf("1"),
             changeActivityToDisplay = {},
-            flipFavorite = {}) {}
+            flipFavorite = {},
+            changeWeatherTarget = {}) {}
       }
     }
   }

--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/favorites/FavoritesScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/favorites/FavoritesScreenTest.kt
@@ -45,7 +45,8 @@ class FavoritesScreenTest {
             centerPoint = LatLng(46.519962, 6.633597),
             favorites = emptyList(),
             changeActivityToDisplay = {},
-            flipFavorite = {}) {}
+            flipFavorite = {},
+            changeWeatherTarget = {}) {}
       }
     }
     composeRule.onNodeWithTag("LoadingBarFavorites").assertIsDisplayed()

--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
@@ -51,7 +51,8 @@ class MoreInfoScreenTest {
           null,
           emptyList(),
           null,
-          {})
+          {},
+          setWeatherBackToUserLoc = {})
     }
   }
 

--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
@@ -12,6 +12,7 @@ import com.lastaoutdoor.lasta.R
 import com.lastaoutdoor.lasta.di.AppModule
 import com.lastaoutdoor.lasta.models.activity.Activity
 import com.lastaoutdoor.lasta.models.activity.ActivityType
+import com.lastaoutdoor.lasta.models.activity.Difficulty
 import com.lastaoutdoor.lasta.models.map.Marker
 import com.lastaoutdoor.lasta.ui.MainActivity
 import com.lastaoutdoor.lasta.viewmodel.MapState
@@ -81,5 +82,20 @@ class MoreInfoScreenTest {
   @Test
   fun moreInfoMapIsDisplayed() {
     composeRule.onNodeWithTag("viewOnMapButton").performClick()
+  }
+
+  @Test
+  fun elevateddiff_isDisplayed() {
+    composeRule.activity.setContent {
+      ElevatedDifficultyDisplay(
+          activityToDisplay = Activity("", 0L, difficulty = Difficulty.NORMAL))
+    }
+    composeRule.onNodeWithTag("elevatedTestTag").assertIsDisplayed()
+    composeRule.onNodeWithTag("elevatedTestTag").performClick()
+    composeRule.activity.setContent {
+      ElevatedDifficultyDisplay(activityToDisplay = Activity("", 0L, difficulty = Difficulty.HARD))
+    }
+    composeRule.onNodeWithTag("elevatedTestTag").assertIsDisplayed()
+    composeRule.onNodeWithTag("elevatedTestTag").performClick()
   }
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/navigation/MainNavGraph.kt
@@ -58,7 +58,7 @@ fun NavGraphBuilder.addMainNavGraph(navController: NavHostController) {
       val selectedMarker = discoverScreenViewModel.selectedMarker.collectAsState().value
       val selectedItinerary = discoverScreenViewModel.selectedItinerary.collectAsState().value
       val markerList = discoverScreenViewModel.markerList.collectAsState().value
-      val weatherViewModel: WeatherViewModel = hiltViewModel(entry)
+      val weatherViewModel: WeatherViewModel = entry.sharedViewModel(navController)
       val weather = weatherViewModel.weather.observeAsState().value
 
       DiscoverScreen(
@@ -77,6 +77,7 @@ fun NavGraphBuilder.addMainNavGraph(navController: NavHostController) {
           { navController.navigate(DestinationRoute.Filter.route) },
           { navController.navigate(DestinationRoute.MoreInfo.route) },
           moreInfoScreenViewModel::changeActivityToDisplay,
+          weatherViewModel::changeLocOfWeather,
           weather,
           mapState,
           discoverScreenViewModel::updatePermission,
@@ -101,11 +102,13 @@ fun NavGraphBuilder.addMainNavGraph(navController: NavHostController) {
       val favorites = favoritesScreenViewModel.favorites.collectAsState().value
       val centerPoint = discoverScreenViewModel.selectedLocality.collectAsState().value.second
       val favoriteIds = favoritesScreenViewModel.favoritesIds.collectAsState().value
+      val weatherViewModel: WeatherViewModel = entry.sharedViewModel(navController)
       FavoritesScreen(
           favorites,
           centerPoint,
           favoriteIds,
           moreInfoScreenViewModel::changeActivityToDisplay,
+          weatherViewModel::changeLocOfWeather,
           preferencesViewModel::flipFavorite) {
             navController.navigate(DestinationRoute.MoreInfo.route)
           }
@@ -173,7 +176,7 @@ fun NavGraphBuilder.addMainNavGraph(navController: NavHostController) {
       val discoverScreenViewModel: DiscoverScreenViewModel = hiltViewModel(entry)
       val moreInfoScreenViewModel: MoreInfoScreenViewModel = entry.sharedViewModel(navController)
       val activityToDisplay = moreInfoScreenViewModel.activityToDisplay.value
-      val weatherViewModel: WeatherViewModel = hiltViewModel(entry)
+      val weatherViewModel: WeatherViewModel = entry.sharedViewModel(navController)
       val weather = weatherViewModel.weather.observeAsState().value
       val mapState = discoverScreenViewModel.mapState.collectAsState().value
       val initialZoom = discoverScreenViewModel.initialZoom
@@ -195,9 +198,9 @@ fun NavGraphBuilder.addMainNavGraph(navController: NavHostController) {
           moreInfoScreenViewModel::goToMarker,
           weather,
           markerList,
-          selectedItinerary) {
-            navController.navigateUp()
-          }
+          selectedItinerary,
+          { navController.navigateUp() },
+          weatherViewModel::fetchWeatherWithUserLoc)
     }
     composable(DestinationRoute.Filter.route) { entry ->
       val preferencesViewModel: PreferencesViewModel = entry.sharedViewModel(navController)

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discover/DiscoverScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discover/DiscoverScreen.kt
@@ -140,7 +140,7 @@ fun DiscoverScreen(
                 changeActivityToDisplay,
                 flipFavorite = flipFavorite,
                 navigateToMoreInfo = navigateToMoreInfo,
-                changeWeatherTarget=changeWeatherTarget)
+                changeWeatherTarget = changeWeatherTarget)
           }
         }
   } else if (screen == DiscoverDisplayType.MAP) {

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discover/DiscoverScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/discover/DiscoverScreen.kt
@@ -82,6 +82,7 @@ fun DiscoverScreen(
     navigateToFilter: () -> Unit,
     navigateToMoreInfo: () -> Unit,
     changeActivityToDisplay: (Activity) -> Unit,
+    changeWeatherTarget: (Activity) -> Unit,
     weather: WeatherResponse?,
     state: MapState,
     updatePermission: (Boolean) -> Unit,
@@ -137,8 +138,9 @@ fun DiscoverScreen(
                 centerPoint,
                 favorites,
                 changeActivityToDisplay,
-                flipFavorite,
-                navigateToMoreInfo)
+                flipFavorite = flipFavorite,
+                navigateToMoreInfo = navigateToMoreInfo,
+                changeWeatherTarget=changeWeatherTarget)
           }
         }
   } else if (screen == DiscoverDisplayType.MAP) {
@@ -338,6 +340,7 @@ fun ActivitiesDisplay(
     centerPoint: LatLng,
     favorites: List<String>,
     changeActivityToDisplay: (Activity) -> Unit,
+    changeWeatherTarget: (Activity) -> Unit,
     flipFavorite: (String) -> Unit,
     navigateToMoreInfo: () -> Unit
 ) {
@@ -351,6 +354,7 @@ fun ActivitiesDisplay(
                 .clickable(
                     onClick = {
                       changeActivityToDisplay(a)
+                      changeWeatherTarget(a)
                       navigateToMoreInfo()
                     })
                 .testTag("${a.activityId}activityCard"),

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/favorites/FavoritesScreen.kt
@@ -17,6 +17,7 @@ fun FavoritesScreen(
     centerPoint: LatLng,
     favorites: List<String>,
     changeActivityToDisplay: (Activity) -> Unit,
+    changeWeatherTarget: (Activity) -> Unit,
     flipFavorite: (String) -> Unit,
     navigateToMoreInfo: () -> Unit
 ) {
@@ -28,6 +29,7 @@ fun FavoritesScreen(
           centerPoint,
           favorites,
           changeActivityToDisplay,
+          changeWeatherTarget,
           flipFavorite,
           navigateToMoreInfo)
     }

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -69,18 +69,15 @@ fun MoreInfoScreen(
 ) {
   var isMapDisplayed = remember { mutableStateOf(false) }
   if (!isMapDisplayed.value) {
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .testTag("MoreInfoComposable")) {
-      LazyColumn(modifier = Modifier
-          .weight(1f)
-          .padding(8.dp)) {
+    Column(modifier = Modifier.fillMaxSize().testTag("MoreInfoComposable")) {
+      LazyColumn(modifier = Modifier.weight(1f).padding(8.dp)) {
         item { Spacer(modifier = Modifier.height(15.dp)) }
         // contains the top icon buttons
-        item { TopBar {
+        item {
+          TopBar {
             navigateBack()
             setWeatherBackToUserLoc()
-        }
+          }
         }
         // displays activity title and duration
         item { ActivityTitleZone(activityToDisplay) }
@@ -93,13 +90,11 @@ fun MoreInfoScreen(
       StartButton()
     }
   } else {
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .testTag("MoreInfoMap")) {
+    Column(modifier = Modifier.fillMaxSize().testTag("MoreInfoMap")) {
       val marker = goToMarker(activityToDisplay)
-      TopBar{
-          navigateBack()
-          setWeatherBackToUserLoc()
+      TopBar {
+        navigateBack()
+        setWeatherBackToUserLoc()
       }
       MapScreen(
           state,
@@ -125,17 +120,13 @@ fun MoreInfoScreen(
 @Composable
 fun StartButton() {
   Row(
-      modifier = Modifier
-          .fillMaxWidth()
-          .testTag("MoreInfoStartButton"),
+      modifier = Modifier.fillMaxWidth().testTag("MoreInfoStartButton"),
       horizontalArrangement = Arrangement.Center) {
         ElevatedButton(
             onClick = {
               /** TODO : Start Activity */
             },
-            modifier = Modifier
-                .fillMaxWidth(0.8f)
-                .height(48.dp), // takes up 80% of the width
+            modifier = Modifier.fillMaxWidth(0.8f).height(48.dp), // takes up 80% of the width
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
               Text(
                   LocalContext.current.getString(R.string.start),
@@ -153,9 +144,7 @@ fun StartButton() {
 // on the map on the right
 @Composable
 fun MiddleZone(activityToDisplay: Activity, isMapDisplayed: MutableState<Boolean>) {
-  Row(modifier = Modifier
-      .fillMaxWidth()
-      .testTag("MoreInfoMiddleZone")) {
+  Row(modifier = Modifier.fillMaxWidth().testTag("MoreInfoMiddleZone")) {
     DiffAndRating(activityToDisplay)
     Spacer(Modifier.weight(1f))
     ViewOnMapButton(isMapDisplayed)
@@ -166,16 +155,12 @@ fun MiddleZone(activityToDisplay: Activity, isMapDisplayed: MutableState<Boolean
 @Composable
 fun ViewOnMapButton(isMapDisplayed: MutableState<Boolean>) {
   Column(
-      modifier = Modifier
-          .padding(vertical = 25.dp)
-          .testTag("viewOnMapButton"),
+      modifier = Modifier.padding(vertical = 25.dp).testTag("viewOnMapButton"),
       horizontalAlignment = Alignment.End) {
         ElevatedButton(
             onClick = { isMapDisplayed.value = true },
             contentPadding = PaddingValues(all = 3.dp),
-            modifier = Modifier
-                .width(130.dp)
-                .height(40.dp),
+            modifier = Modifier.width(130.dp).height(40.dp),
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
               Text(
                   LocalContext.current.getString(R.string.on_map),
@@ -240,9 +225,7 @@ fun Star(iconId: Int) {
       painter = painterResource(iconId),
       contentDescription = "Rating Star",
       tint = PrimaryBlue,
-      modifier = Modifier
-          .width(17.dp)
-          .height(16.dp))
+      modifier = Modifier.width(17.dp).height(16.dp))
 }
 
 // Displays the difficulty of the activity
@@ -257,9 +240,7 @@ fun ElevatedDifficultyDisplay(activityToDisplay: Activity) {
   ElevatedButton(
       onClick = { /*TODO let user change activity difficulty */},
       contentPadding = PaddingValues(all = 3.dp),
-      modifier = Modifier
-          .width(80.dp)
-          .height(24.dp),
+      modifier = Modifier.width(80.dp).height(24.dp),
       colors = ButtonDefaults.buttonColors(containerColor = difficultyColor)) {
         Text(
             activityToDisplay.difficulty.toString(),
@@ -277,9 +258,7 @@ fun ElevatedDifficultyDisplay(activityToDisplay: Activity) {
 // Top Bar that displays the four clickable logos with distinct usages
 @Composable
 fun TopBar(navigateBack: () -> Unit) {
-  Row(modifier = Modifier
-      .fillMaxWidth()
-      .testTag("Top Bar")) {
+  Row(modifier = Modifier.fillMaxWidth().testTag("Top Bar")) {
     TopBarLogo(R.drawable.arrow_back) { navigateBack() }
     Spacer(modifier = Modifier.weight(1f))
     TopBarLogo(R.drawable.download_button) {}
@@ -295,9 +274,7 @@ fun TopBarLogo(logoPainterId: Int, isFriendProf: Boolean = false, f: () -> Unit)
     Icon(
         painter = painterResource(id = logoPainterId),
         contentDescription = "Top Bar logo $logoPainterId",
-        modifier = Modifier
-            .width(26.dp)
-            .height(26.dp),
+        modifier = Modifier.width(26.dp).height(26.dp),
         // put to white if bool else put to default color
         tint = if (isFriendProf) Color.White else MaterialTheme.colorScheme.onSurface)
   }
@@ -323,10 +300,7 @@ fun ActivityPicture() {
     Image(
         painter = painterResource(id = R.drawable.ellipse),
         contentDescription = "Soon Activity Picture",
-        modifier = Modifier
-            .padding(5.dp)
-            .width(70.dp)
-            .height(70.dp))
+        modifier = Modifier.padding(5.dp).width(70.dp).height(70.dp))
   }
 }
 
@@ -355,11 +329,10 @@ fun ElevatedActivityType(activityToDisplay: Activity) {
       onClick = {},
       contentPadding = PaddingValues(all = 3.dp),
       modifier =
-      Modifier
-          .padding(3.dp)
-          .width(64.dp)
-          .height(20.dp)
-          .testTag("MoreInfoActivityTypeComposable"),
+          Modifier.padding(3.dp)
+              .width(64.dp)
+              .height(20.dp)
+              .testTag("MoreInfoActivityTypeComposable"),
       colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
         Text(
             text = activityToDisplay.activityType.toString(),

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -240,7 +240,7 @@ fun ElevatedDifficultyDisplay(activityToDisplay: Activity) {
   ElevatedButton(
       onClick = { /*TODO let user change activity difficulty */},
       contentPadding = PaddingValues(all = 3.dp),
-      modifier = Modifier.width(80.dp).height(24.dp),
+      modifier = Modifier.width(80.dp).height(24.dp).testTag("elevatedTestTag"),
       colors = ButtonDefaults.buttonColors(containerColor = difficultyColor)) {
         Text(
             activityToDisplay.difficulty.toString(),

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -63,16 +63,25 @@ fun MoreInfoScreen(
     goToMarker: (Activity) -> Marker,
     weather: WeatherResponse?,
     markerList: List<Marker>,
-    selectedItenary: MapItinerary?,
+    selectedItinary: MapItinerary?,
     navigateBack: () -> Unit,
+    setWeatherBackToUserLoc: () -> Unit
 ) {
   var isMapDisplayed = remember { mutableStateOf(false) }
   if (!isMapDisplayed.value) {
-    Column(modifier = Modifier.fillMaxSize().testTag("MoreInfoComposable")) {
-      LazyColumn(modifier = Modifier.weight(1f).padding(8.dp)) {
+    Column(modifier = Modifier
+        .fillMaxSize()
+        .testTag("MoreInfoComposable")) {
+      LazyColumn(modifier = Modifier
+          .weight(1f)
+          .padding(8.dp)) {
         item { Spacer(modifier = Modifier.height(15.dp)) }
         // contains the top icon buttons
-        item { TopBar(navigateBack) }
+        item { TopBar {
+            navigateBack()
+            setWeatherBackToUserLoc()
+        }
+        }
         // displays activity title and duration
         item { ActivityTitleZone(activityToDisplay) }
         item {
@@ -84,9 +93,14 @@ fun MoreInfoScreen(
       StartButton()
     }
   } else {
-    Column(modifier = Modifier.fillMaxSize().testTag("MoreInfoMap")) {
+    Column(modifier = Modifier
+        .fillMaxSize()
+        .testTag("MoreInfoMap")) {
       val marker = goToMarker(activityToDisplay)
-      TopBar(navigateBack)
+      TopBar{
+          navigateBack()
+          setWeatherBackToUserLoc()
+      }
       MapScreen(
           state,
           updatePermission,
@@ -97,7 +111,7 @@ fun MoreInfoScreen(
           clearSelectedItinerary,
           selectedZoom,
           marker,
-          selectedItenary,
+          selectedItinary,
           markerList,
       ) {
         clearSelectedItinerary()
@@ -111,13 +125,17 @@ fun MoreInfoScreen(
 @Composable
 fun StartButton() {
   Row(
-      modifier = Modifier.fillMaxWidth().testTag("MoreInfoStartButton"),
+      modifier = Modifier
+          .fillMaxWidth()
+          .testTag("MoreInfoStartButton"),
       horizontalArrangement = Arrangement.Center) {
         ElevatedButton(
             onClick = {
               /** TODO : Start Activity */
             },
-            modifier = Modifier.fillMaxWidth(0.8f).height(48.dp), // takes up 80% of the width
+            modifier = Modifier
+                .fillMaxWidth(0.8f)
+                .height(48.dp), // takes up 80% of the width
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
               Text(
                   LocalContext.current.getString(R.string.start),
@@ -135,7 +153,9 @@ fun StartButton() {
 // on the map on the right
 @Composable
 fun MiddleZone(activityToDisplay: Activity, isMapDisplayed: MutableState<Boolean>) {
-  Row(modifier = Modifier.fillMaxWidth().testTag("MoreInfoMiddleZone")) {
+  Row(modifier = Modifier
+      .fillMaxWidth()
+      .testTag("MoreInfoMiddleZone")) {
     DiffAndRating(activityToDisplay)
     Spacer(Modifier.weight(1f))
     ViewOnMapButton(isMapDisplayed)
@@ -146,12 +166,16 @@ fun MiddleZone(activityToDisplay: Activity, isMapDisplayed: MutableState<Boolean
 @Composable
 fun ViewOnMapButton(isMapDisplayed: MutableState<Boolean>) {
   Column(
-      modifier = Modifier.padding(vertical = 25.dp).testTag("viewOnMapButton"),
+      modifier = Modifier
+          .padding(vertical = 25.dp)
+          .testTag("viewOnMapButton"),
       horizontalAlignment = Alignment.End) {
         ElevatedButton(
             onClick = { isMapDisplayed.value = true },
             contentPadding = PaddingValues(all = 3.dp),
-            modifier = Modifier.width(130.dp).height(40.dp),
+            modifier = Modifier
+                .width(130.dp)
+                .height(40.dp),
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
               Text(
                   LocalContext.current.getString(R.string.on_map),
@@ -216,7 +240,9 @@ fun Star(iconId: Int) {
       painter = painterResource(iconId),
       contentDescription = "Rating Star",
       tint = PrimaryBlue,
-      modifier = Modifier.width(17.dp).height(16.dp))
+      modifier = Modifier
+          .width(17.dp)
+          .height(16.dp))
 }
 
 // Displays the difficulty of the activity
@@ -231,7 +257,9 @@ fun ElevatedDifficultyDisplay(activityToDisplay: Activity) {
   ElevatedButton(
       onClick = { /*TODO let user change activity difficulty */},
       contentPadding = PaddingValues(all = 3.dp),
-      modifier = Modifier.width(80.dp).height(24.dp),
+      modifier = Modifier
+          .width(80.dp)
+          .height(24.dp),
       colors = ButtonDefaults.buttonColors(containerColor = difficultyColor)) {
         Text(
             activityToDisplay.difficulty.toString(),
@@ -249,7 +277,9 @@ fun ElevatedDifficultyDisplay(activityToDisplay: Activity) {
 // Top Bar that displays the four clickable logos with distinct usages
 @Composable
 fun TopBar(navigateBack: () -> Unit) {
-  Row(modifier = Modifier.fillMaxWidth().testTag("Top Bar")) {
+  Row(modifier = Modifier
+      .fillMaxWidth()
+      .testTag("Top Bar")) {
     TopBarLogo(R.drawable.arrow_back) { navigateBack() }
     Spacer(modifier = Modifier.weight(1f))
     TopBarLogo(R.drawable.download_button) {}
@@ -265,7 +295,9 @@ fun TopBarLogo(logoPainterId: Int, isFriendProf: Boolean = false, f: () -> Unit)
     Icon(
         painter = painterResource(id = logoPainterId),
         contentDescription = "Top Bar logo $logoPainterId",
-        modifier = Modifier.width(26.dp).height(26.dp),
+        modifier = Modifier
+            .width(26.dp)
+            .height(26.dp),
         // put to white if bool else put to default color
         tint = if (isFriendProf) Color.White else MaterialTheme.colorScheme.onSurface)
   }
@@ -291,7 +323,10 @@ fun ActivityPicture() {
     Image(
         painter = painterResource(id = R.drawable.ellipse),
         contentDescription = "Soon Activity Picture",
-        modifier = Modifier.padding(5.dp).width(70.dp).height(70.dp))
+        modifier = Modifier
+            .padding(5.dp)
+            .width(70.dp)
+            .height(70.dp))
   }
 }
 
@@ -320,10 +355,11 @@ fun ElevatedActivityType(activityToDisplay: Activity) {
       onClick = {},
       contentPadding = PaddingValues(all = 3.dp),
       modifier =
-          Modifier.padding(3.dp)
-              .width(64.dp)
-              .height(20.dp)
-              .testTag("MoreInfoActivityTypeComposable"),
+      Modifier
+          .padding(3.dp)
+          .width(64.dp)
+          .height(20.dp)
+          .testTag("MoreInfoActivityTypeComposable"),
       colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
         Text(
             text = activityToDisplay.activityType.toString(),

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -63,7 +63,7 @@ fun MoreInfoScreen(
     goToMarker: (Activity) -> Marker,
     weather: WeatherResponse?,
     markerList: List<Marker>,
-    selectedItinary: MapItinerary?,
+    selectedItinerary: MapItinerary?,
     navigateBack: () -> Unit,
     setWeatherBackToUserLoc: () -> Unit
 ) {
@@ -106,7 +106,7 @@ fun MoreInfoScreen(
           clearSelectedItinerary,
           selectedZoom,
           marker,
-          selectedItinary,
+          selectedItinerary,
           markerList,
       ) {
         clearSelectedItinerary()

--- a/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/WeatherViewModel.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/WeatherViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.lastaoutdoor.lasta.data.api.weather.WeatherResponse
+import com.lastaoutdoor.lasta.models.activity.Activity
 import com.lastaoutdoor.lasta.repository.api.WeatherRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -31,10 +32,10 @@ constructor(private val weatherRepository: WeatherRepository, application: Appli
   val weather: LiveData<WeatherResponse> = _weather
 
   init {
-    fetchWeather()
+    fetchWeatherWithUserLoc()
   }
 
-  private fun fetchWeather() {
+  fun fetchWeatherWithUserLoc() {
     if (ContextCompat.checkSelfPermission(
         getApplication(), Manifest.permission.ACCESS_FINE_LOCATION) ==
         PackageManager.PERMISSION_GRANTED) {
@@ -46,6 +47,17 @@ constructor(private val weatherRepository: WeatherRepository, application: Appli
         } catch (e: Exception) {
           e.printStackTrace()
         }
+      }
+    }
+  }
+
+  fun changeLocOfWeather(a:Activity) {
+    viewModelScope.launch {
+      try {
+        val weather = weatherRepository.getWeatherWithLoc(a.startPosition.lat, a.startPosition.lon)
+        _weather.postValue(weather)
+      } catch (e: Exception) {
+        e.printStackTrace()
       }
     }
   }

--- a/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/WeatherViewModel.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/viewmodel/WeatherViewModel.kt
@@ -51,7 +51,7 @@ constructor(private val weatherRepository: WeatherRepository, application: Appli
     }
   }
 
-  fun changeLocOfWeather(a:Activity) {
+  fun changeLocOfWeather(a: Activity) {
     viewModelScope.launch {
       try {
         val weather = weatherRepository.getWeatherWithLoc(a.startPosition.lat, a.startPosition.lon)

--- a/app/src/test/java/com/lastaoutdoor/lasta/data/api/weather/WeatherRepositoryImplTest.kt
+++ b/app/src/test/java/com/lastaoutdoor/lasta/data/api/weather/WeatherRepositoryImplTest.kt
@@ -1,0 +1,60 @@
+package com.lastaoutdoor.lasta.data.api.weather
+
+import com.lastaoutdoor.lasta.BuildConfig
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+
+class WeatherRepositoryImplTest {
+  @Mock lateinit var weatherApiService: WeatherApiService
+
+  private lateinit var weatherRepository: WeatherRepositoryImpl
+
+  @Before
+  fun setup() {
+    MockitoAnnotations.initMocks(this)
+    weatherRepository = WeatherRepositoryImpl(weatherApiService)
+  }
+
+  @Test
+  fun testGetCurrentWeather() {
+    // Mock response from WeatherApiService
+    val expectedResponse = WeatherResponse("name", Main(2.0, 3.0), listOf(), Wind(4.0))
+    runBlocking {
+      `when`(weatherApiService.getCurrentWeather("cityName", BuildConfig.WEATHER_API_KEY))
+          .thenReturn(expectedResponse)
+    }
+
+    // Call the method under test
+    val actualResponse = runBlocking { weatherRepository.getCurrentWeather("cityName") }
+
+    // Verify that the method from WeatherApiService was called with the correct arguments
+    runBlocking {
+      `when`(weatherApiService.getCurrentWeather("cityName", BuildConfig.WEATHER_API_KEY))
+          .thenReturn(expectedResponse)
+    }
+    assertEquals(expectedResponse, actualResponse)
+  }
+
+  @Test
+  fun testGetWeatherWithLoc() {
+    // Mock response from WeatherApiService
+    val expectedResponse = WeatherResponse("name", Main(2.0, 3.0), listOf(), Wind(4.0))
+    runBlocking {
+      `when`(weatherApiService.getWeatherWithLoc(0.0, 0.0, "apiKey")).thenReturn(expectedResponse)
+    }
+
+    // Call the method under test
+    val actualResponse = runBlocking { weatherRepository.getWeatherWithLoc(0.0, 0.0) }
+
+    // Verify that the method from WeatherApiService was called with the correct arguments
+    runBlocking {
+      `when`(weatherApiService.getWeatherWithLoc(0.0, 0.0, "apiKey")).thenReturn(expectedResponse)
+    }
+    assertEquals(null, actualResponse)
+  }
+}


### PR DESCRIPTION
- Modified the `WeatherActivityViewModel` so that you can switch between weather for the current user location and weather for target location in latitude/longitude passed as arguments. The app therefore displays the current location weather report on the `Discover` tab, and the weather on the `More Info` screen is from the displayed activity location.
(FYI, `Montain View` is the name of the city where my emulator seems to be located, as silly as it sounds)

![image](https://github.com/LASTA-OUTDOOR/lasta/assets/100190035/64a99835-574f-45bb-9d75-2b6b136ba33d)

![image](https://github.com/LASTA-OUTDOOR/lasta/assets/100190035/62a46dc9-4523-4b88-9a3b-90262e21fd2e)

- The `WeatherActivityViewModel` is now also a shared view model so that the current weather isn't related to the `Composable` that builds it

- Tried to add test suites to `WeatherActivityViewModel`, but the need of an `Application` that validates that the user authorized location usage seems to make it difficult and I didn't achieve it for now. Maybe this is why the already present test is commented ? To compensate for this lack of coverage, I added tests for `WeatherRepositoryImpl` and additional coverage to `MoreInfoScreen`
