### PR TITLE
Share button for activities

### DIFF
--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
@@ -76,10 +76,22 @@ class MoreInfoScreenTest {
   @Test
   fun topBar_isDisplayedAndClicked() {
     composeRule.onNodeWithTag("Top Bar").assertIsDisplayed()
+    //download button
     composeRule
         .onNodeWithContentDescription("Top Bar logo ${R.drawable.download_button}")
         .assertIsDisplayed()
+    composeRule.onNodeWithContentDescription("Top Bar logo ${R.drawable.download_button}").performClick()
+
+    //back button
+    composeRule
+        .onNodeWithContentDescription("Top Bar logo ${R.drawable.arrow_back}")
+        .assertIsDisplayed()
     composeRule.onNodeWithContentDescription("Top Bar logo ${R.drawable.arrow_back}").performClick()
+
+    //share button
+    composeRule
+        .onNodeWithContentDescription("Top Bar logo ${R.drawable.share}")
+        .assertIsDisplayed()
   }
 
   // Test that the more info screen is displayed

--- a/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
+++ b/app/src/androidTest/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreenTest.kt
@@ -76,22 +76,24 @@ class MoreInfoScreenTest {
   @Test
   fun topBar_isDisplayedAndClicked() {
     composeRule.onNodeWithTag("Top Bar").assertIsDisplayed()
-    //download button
+    // download button
     composeRule
         .onNodeWithContentDescription("Top Bar logo ${R.drawable.download_button}")
         .assertIsDisplayed()
-    composeRule.onNodeWithContentDescription("Top Bar logo ${R.drawable.download_button}").performClick()
+    composeRule
+        .onNodeWithContentDescription("Top Bar logo ${R.drawable.download_button}")
+        .performClick()
 
-    //back button
+    // back button
     composeRule
         .onNodeWithContentDescription("Top Bar logo ${R.drawable.arrow_back}")
         .assertIsDisplayed()
     composeRule.onNodeWithContentDescription("Top Bar logo ${R.drawable.arrow_back}").performClick()
 
-    //share button
-    composeRule
-        .onNodeWithContentDescription("Top Bar logo ${R.drawable.share}")
-        .assertIsDisplayed()
+    // share button
+    composeRule.onNodeWithContentDescription("Top Bar logo ${R.drawable.share}").assertIsDisplayed()
+
+    composeRule.onNodeWithContentDescription("Top Bar logo ${R.drawable.share}").performClick()
   }
 
   // Test that the more info screen is displayed

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/components/ShareSheets.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/components/ShareSheets.kt
@@ -1,0 +1,24 @@
+package com.lastaoutdoor.lasta.ui.components
+
+import android.content.Context
+import android.content.Intent
+import android.text.Html
+import androidx.core.text.HtmlCompat
+import com.lastaoutdoor.lasta.R
+import com.lastaoutdoor.lasta.models.activity.Activity
+
+
+//Opens the android share sheet, will contain a description and a link to the activity -> will be used to share activities
+fun shareActivity(activity : Activity, context: Context) {
+
+    val sendIntent: Intent = Intent().apply {
+        action = Intent.ACTION_SEND
+        putExtra(Intent.EXTRA_TEXT,
+            context.getString(R.string.share_body) + "\n${activity.name} \nhttps://lasta.jerem.ch/activities/${activity.activityId}"
+        )
+        type = "text/plain"
+    }
+
+    context.startActivity(Intent.createChooser(sendIntent, context.getString(R.string.share_title)))
+
+}

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/components/ShareSheets.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/components/ShareSheets.kt
@@ -2,23 +2,22 @@ package com.lastaoutdoor.lasta.ui.components
 
 import android.content.Context
 import android.content.Intent
-import android.text.Html
-import androidx.core.text.HtmlCompat
 import com.lastaoutdoor.lasta.R
 import com.lastaoutdoor.lasta.models.activity.Activity
 
+// Opens the android share sheet, will contain a description and a link to the activity -> will be
+// used to share activities
+fun shareActivity(activity: Activity, context: Context) {
 
-//Opens the android share sheet, will contain a description and a link to the activity -> will be used to share activities
-fun shareActivity(activity : Activity, context: Context) {
-
-    val sendIntent: Intent = Intent().apply {
+  val sendIntent: Intent =
+      Intent().apply {
         action = Intent.ACTION_SEND
-        putExtra(Intent.EXTRA_TEXT,
-            context.getString(R.string.share_body) + "\n${activity.name} \nhttps://lasta.jerem.ch/activities/${activity.activityId}"
-        )
+        putExtra(
+            Intent.EXTRA_TEXT,
+            context.getString(R.string.share_body) +
+                "\n${activity.name} \nhttps://lasta.jerem.ch/activities/${activity.activityId}")
         type = "text/plain"
-    }
+      }
 
-    context.startActivity(Intent.createChooser(sendIntent, context.getString(R.string.share_title)))
-
+  context.startActivity(Intent.createChooser(sendIntent, context.getString(R.string.share_title)))
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/components/ShareSheets.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/components/ShareSheets.kt
@@ -5,19 +5,37 @@ import android.content.Intent
 import com.lastaoutdoor.lasta.R
 import com.lastaoutdoor.lasta.models.activity.Activity
 
-// Opens the android share sheet, will contain a description and a link to the activity -> will be
-// used to share activities
-fun shareActivity(activity: Activity, context: Context) {
-
+/**
+ * Share a text to other apps (share sheet)
+ *
+ * @param content the text to share
+ * @param context the context of the app
+ * @return void
+ */
+private fun shareText(content: String, context: Context) {
   val sendIntent: Intent =
       Intent().apply {
         action = Intent.ACTION_SEND
-        putExtra(
-            Intent.EXTRA_TEXT,
-            context.getString(R.string.share_body) +
-                "\n${activity.name} \nhttps://lasta.jerem.ch/activities/${activity.activityId}")
+        putExtra(Intent.EXTRA_TEXT, content)
         type = "text/plain"
       }
-
   context.startActivity(Intent.createChooser(sendIntent, context.getString(R.string.share_title)))
+}
+
+/**
+ * Starts a share sheet to share an activity
+ *
+ * @param activity the activity to share
+ * @param context the context of the app
+ * @return void
+ */
+fun shareActivity(activity: Activity, context: Context) {
+
+  val textFromActivity =
+      context.getString(R.string.share_body) +
+          "\n${activity.name} \n" +
+          context.getString(R.string.share_base_url) +
+          activity.activityId
+
+  shareText(textFromActivity, context)
 }

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -58,8 +58,8 @@ import com.lastaoutdoor.lasta.models.map.MapItinerary
 import com.lastaoutdoor.lasta.models.map.Marker
 import com.lastaoutdoor.lasta.models.user.UserModel
 import com.lastaoutdoor.lasta.ui.components.SeparatorComponent
-import com.lastaoutdoor.lasta.ui.components.shareActivity
 import com.lastaoutdoor.lasta.ui.components.WeatherReportBig
+import com.lastaoutdoor.lasta.ui.components.shareActivity
 import com.lastaoutdoor.lasta.ui.screen.map.mapScreen
 import com.lastaoutdoor.lasta.ui.theme.Black
 import com.lastaoutdoor.lasta.ui.theme.GreenDifficulty
@@ -100,9 +100,7 @@ fun MoreInfoScreen(
   val text = remember { mutableStateOf("") }
   if (!isMapDisplayed.value) {
     Column(
-        modifier = Modifier
-            .fillMaxSize(1f)
-            .testTag("MoreInfoComposable"),
+        modifier = Modifier.fillMaxSize(1f).testTag("MoreInfoComposable"),
         verticalArrangement = Arrangement.SpaceBetween) {
           Column(modifier = Modifier.padding(8.dp)) {
             Spacer(modifier = Modifier.height(15.dp))
@@ -140,9 +138,7 @@ fun MoreInfoScreen(
               }
         }
   } else {
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .testTag("MoreInfoMap")) {
+    Column(modifier = Modifier.fillMaxSize().testTag("MoreInfoMap")) {
       val marker = goToMarker(activityToDisplay)
       TopBar(activityToDisplay, downloadActivity) {
         fetchActivities()
@@ -173,17 +169,13 @@ fun MoreInfoScreen(
 @Composable
 fun StartButton() {
   Row(
-      modifier = Modifier
-          .fillMaxWidth()
-          .testTag("MoreInfoStartButton"),
+      modifier = Modifier.fillMaxWidth().testTag("MoreInfoStartButton"),
       horizontalArrangement = Arrangement.Center) {
         ElevatedButton(
             onClick = {
               /** TODO : Start Activity */
             },
-            modifier = Modifier
-                .fillMaxWidth(0.8f)
-                .height(48.dp), // takes up 80% of the width
+            modifier = Modifier.fillMaxWidth(0.8f).height(48.dp), // takes up 80% of the width
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
               Text(
                   LocalContext.current.getString(R.string.start),
@@ -212,9 +204,7 @@ fun MiddleZone(
     fetchActivities: () -> Unit
 ) {
   Row(
-      modifier = Modifier
-          .fillMaxWidth()
-          .testTag("MoreInfoMiddleZone"),
+      modifier = Modifier.fillMaxWidth().testTag("MoreInfoMiddleZone"),
       horizontalArrangement = Arrangement.SpaceBetween) {
         RatingLine(
             activityToDisplay,
@@ -234,16 +224,12 @@ fun MiddleZone(
 @Composable
 fun ViewOnMapButton(isMapDisplayed: MutableState<Boolean>) {
   Column(
-      modifier = Modifier
-          .padding(vertical = 25.dp)
-          .testTag("viewOnMapButton"),
+      modifier = Modifier.padding(vertical = 25.dp).testTag("viewOnMapButton"),
       horizontalAlignment = Alignment.End) {
         ElevatedButton(
             onClick = { isMapDisplayed.value = true },
             contentPadding = PaddingValues(all = 3.dp),
-            modifier = Modifier
-                .width(130.dp)
-                .height(40.dp),
+            modifier = Modifier.width(130.dp).height(40.dp),
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
               Text(
                   LocalContext.current.getString(R.string.on_map),
@@ -336,9 +322,7 @@ fun Star(iconId: Int) {
       painter = painterResource(iconId),
       contentDescription = "Rating Star",
       tint = PrimaryBlue,
-      modifier = Modifier
-          .width(17.dp)
-          .height(16.dp))
+      modifier = Modifier.width(17.dp).height(16.dp))
 }
 
 // Displays the difficulty of the activity
@@ -353,10 +337,7 @@ fun ElevatedDifficultyDisplay(activityToDisplay: Activity) {
   ElevatedButton(
       onClick = { /*TODO let user change activity difficulty */},
       contentPadding = PaddingValues(all = 3.dp),
-      modifier = Modifier
-          .width(80.dp)
-          .height(24.dp)
-          .testTag("elevatedTestTag"),
+      modifier = Modifier.width(80.dp).height(24.dp).testTag("elevatedTestTag"),
       colors = ButtonDefaults.buttonColors(containerColor = difficultyColor)) {
         Text(
             activityToDisplay.difficulty.toString(),
@@ -385,12 +366,9 @@ fun TopBar(
     TopBarLogo(R.drawable.arrow_back) { navigateBack() }
     Spacer(modifier = Modifier.weight(1f))
     TopBarLogo(R.drawable.download_button) { downloadActivity(activityToDisplay) }
-    TopBarLogo(R.drawable.share) {
-        shareActivity(activityToDisplay, context)
-    }
+    TopBarLogo(R.drawable.share) { shareActivity(activityToDisplay, context) }
     TopBarLogo(R.drawable.favourite) {}
   }
-
 }
 
 // Logo of the top bar
@@ -400,9 +378,7 @@ fun TopBarLogo(logoPainterId: Int, isFriendProf: Boolean = false, f: () -> Unit)
     Icon(
         painter = painterResource(id = logoPainterId),
         contentDescription = "Top Bar logo $logoPainterId",
-        modifier = Modifier
-            .width(26.dp)
-            .height(26.dp),
+        modifier = Modifier.width(26.dp).height(26.dp),
         // put to white if bool else put to default color
         tint = if (isFriendProf) Color.White else MaterialTheme.colorScheme.onSurface)
   }
@@ -428,10 +404,7 @@ fun ActivityPicture() {
     Image(
         painter = painterResource(id = R.drawable.ellipse),
         contentDescription = "Soon Activity Picture",
-        modifier = Modifier
-            .padding(5.dp)
-            .width(70.dp)
-            .height(70.dp))
+        modifier = Modifier.padding(5.dp).width(70.dp).height(70.dp))
   }
 }
 
@@ -460,11 +433,10 @@ fun ElevatedActivityType(activityToDisplay: Activity) {
       onClick = {},
       contentPadding = PaddingValues(all = 3.dp),
       modifier =
-      Modifier
-          .padding(3.dp)
-          .width(64.dp)
-          .height(20.dp)
-          .testTag("MoreInfoActivityTypeComposable"),
+          Modifier.padding(3.dp)
+              .width(64.dp)
+              .height(20.dp)
+              .testTag("MoreInfoActivityTypeComposable"),
       colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
         Text(
             text = activityToDisplay.activityType.toString(),
@@ -496,9 +468,7 @@ fun AddRatingButton(
     ModalBottomSheet(
         onDismissRequest = { isReviewing.value = false }, modifier = Modifier.fillMaxWidth()) {
           Column(
-              modifier = Modifier
-                  .padding(30.dp)
-                  .testTag("ModalBottomSheet"),
+              modifier = Modifier.padding(30.dp).testTag("ModalBottomSheet"),
               horizontalAlignment = Alignment.CenterHorizontally) {
                 val selectedStarCount = remember { mutableIntStateOf(1) }
                 Text(
@@ -559,10 +529,7 @@ fun AddRatingButton(
                       isReviewing.value = false
                     },
                     modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(top = 10.dp)
-                        .testTag("PublishButton"),
+                        Modifier.fillMaxWidth().padding(top = 10.dp).testTag("PublishButton"),
                     colors =
                         ButtonDefaults.buttonColors(
                             containerColor = PrimaryBlue, contentColor = Color.White)) {
@@ -581,15 +548,11 @@ fun AddRatingButton(
                 contentColor = Color.Black,
                 disabledContentColor = Color.Yellow,
                 disabledContainerColor = Color.Black),
-        modifier = Modifier
-            .size(25.dp)
-            .testTag("AddRatingButton")) {
+        modifier = Modifier.size(25.dp).testTag("AddRatingButton")) {
           Icon(
               painter = painterResource(id = R.drawable.plus),
               contentDescription = "Add Rating",
-              modifier = Modifier
-                  .width(16.dp)
-                  .height(16.dp),
+              modifier = Modifier.width(16.dp).height(16.dp),
               tint = Color.Black,
           )
         }
@@ -599,9 +562,7 @@ fun AddRatingButton(
 @Composable
 fun StarButtons(selectedStarCount: MutableState<Int>) {
   Row(
-      modifier = Modifier
-          .padding(2.dp)
-          .testTag("StarButtons"),
+      modifier = Modifier.padding(2.dp).testTag("StarButtons"),
       verticalAlignment = Alignment.CenterVertically) {
         for (i in 1..5) {
           val isSelected = i <= selectedStarCount.value
@@ -611,9 +572,7 @@ fun StarButtons(selectedStarCount: MutableState<Int>) {
                     painterResource(
                         id = if (isSelected) R.drawable.filled_star else R.drawable.empty_star),
                 contentDescription = "Star $i",
-                modifier = Modifier
-                    .width(16.dp)
-                    .height(16.dp),
+                modifier = Modifier.width(16.dp).height(16.dp),
                 tint = if (isSelected) MaterialTheme.colorScheme.primary else Color.Black)
           }
         }
@@ -624,11 +583,10 @@ fun StarButtons(selectedStarCount: MutableState<Int>) {
 fun RatingCard(rating: Rating, usersList: List<UserModel?>) {
   Card(
       modifier =
-      Modifier
-          .fillMaxWidth()
-          .padding(vertical = 8.dp, horizontal = 16.dp)
-          .clickable(onClick = {})
-          .testTag("RatingCard"),
+          Modifier.fillMaxWidth()
+              .padding(vertical = 8.dp, horizontal = 16.dp)
+              .clickable(onClick = {})
+              .testTag("RatingCard"),
       shape = RoundedCornerShape(8.dp),
       elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
       colors =
@@ -644,12 +602,10 @@ fun RatingCard(rating: Rating, usersList: List<UserModel?>) {
                 model = usersList.find { it?.userId == rating.userId }?.profilePictureUrl,
                 contentDescription = "Profile picture",
                 modifier =
-                Modifier
-                    .size(30.dp)
-                    .clip(CircleShape)
-                    .border(
-                        2.dp, MaterialTheme.colorScheme.onPrimary, RoundedCornerShape(100.dp)
-                    ),
+                    Modifier.size(30.dp)
+                        .clip(CircleShape)
+                        .border(
+                            2.dp, MaterialTheme.colorScheme.onPrimary, RoundedCornerShape(100.dp)),
                 contentScale = ContentScale.Crop,
                 error = painterResource(id = R.drawable.default_profile_icon))
             Spacer(modifier = Modifier.width(10.dp))

--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/screen/moreinfo/MoreInfoScreen.kt
@@ -32,11 +32,9 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -60,6 +58,7 @@ import com.lastaoutdoor.lasta.models.map.MapItinerary
 import com.lastaoutdoor.lasta.models.map.Marker
 import com.lastaoutdoor.lasta.models.user.UserModel
 import com.lastaoutdoor.lasta.ui.components.SeparatorComponent
+import com.lastaoutdoor.lasta.ui.components.shareActivity
 import com.lastaoutdoor.lasta.ui.components.WeatherReportBig
 import com.lastaoutdoor.lasta.ui.screen.map.mapScreen
 import com.lastaoutdoor.lasta.ui.theme.Black
@@ -101,7 +100,9 @@ fun MoreInfoScreen(
   val text = remember { mutableStateOf("") }
   if (!isMapDisplayed.value) {
     Column(
-        modifier = Modifier.fillMaxSize(1f).testTag("MoreInfoComposable"),
+        modifier = Modifier
+            .fillMaxSize(1f)
+            .testTag("MoreInfoComposable"),
         verticalArrangement = Arrangement.SpaceBetween) {
           Column(modifier = Modifier.padding(8.dp)) {
             Spacer(modifier = Modifier.height(15.dp))
@@ -139,7 +140,9 @@ fun MoreInfoScreen(
               }
         }
   } else {
-    Column(modifier = Modifier.fillMaxSize().testTag("MoreInfoMap")) {
+    Column(modifier = Modifier
+        .fillMaxSize()
+        .testTag("MoreInfoMap")) {
       val marker = goToMarker(activityToDisplay)
       TopBar(activityToDisplay, downloadActivity) {
         fetchActivities()
@@ -170,13 +173,17 @@ fun MoreInfoScreen(
 @Composable
 fun StartButton() {
   Row(
-      modifier = Modifier.fillMaxWidth().testTag("MoreInfoStartButton"),
+      modifier = Modifier
+          .fillMaxWidth()
+          .testTag("MoreInfoStartButton"),
       horizontalArrangement = Arrangement.Center) {
         ElevatedButton(
             onClick = {
               /** TODO : Start Activity */
             },
-            modifier = Modifier.fillMaxWidth(0.8f).height(48.dp), // takes up 80% of the width
+            modifier = Modifier
+                .fillMaxWidth(0.8f)
+                .height(48.dp), // takes up 80% of the width
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
               Text(
                   LocalContext.current.getString(R.string.start),
@@ -205,7 +212,9 @@ fun MiddleZone(
     fetchActivities: () -> Unit
 ) {
   Row(
-      modifier = Modifier.fillMaxWidth().testTag("MoreInfoMiddleZone"),
+      modifier = Modifier
+          .fillMaxWidth()
+          .testTag("MoreInfoMiddleZone"),
       horizontalArrangement = Arrangement.SpaceBetween) {
         RatingLine(
             activityToDisplay,
@@ -225,12 +234,16 @@ fun MiddleZone(
 @Composable
 fun ViewOnMapButton(isMapDisplayed: MutableState<Boolean>) {
   Column(
-      modifier = Modifier.padding(vertical = 25.dp).testTag("viewOnMapButton"),
+      modifier = Modifier
+          .padding(vertical = 25.dp)
+          .testTag("viewOnMapButton"),
       horizontalAlignment = Alignment.End) {
         ElevatedButton(
             onClick = { isMapDisplayed.value = true },
             contentPadding = PaddingValues(all = 3.dp),
-            modifier = Modifier.width(130.dp).height(40.dp),
+            modifier = Modifier
+                .width(130.dp)
+                .height(40.dp),
             colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
               Text(
                   LocalContext.current.getString(R.string.on_map),
@@ -323,7 +336,9 @@ fun Star(iconId: Int) {
       painter = painterResource(iconId),
       contentDescription = "Rating Star",
       tint = PrimaryBlue,
-      modifier = Modifier.width(17.dp).height(16.dp))
+      modifier = Modifier
+          .width(17.dp)
+          .height(16.dp))
 }
 
 // Displays the difficulty of the activity
@@ -338,7 +353,10 @@ fun ElevatedDifficultyDisplay(activityToDisplay: Activity) {
   ElevatedButton(
       onClick = { /*TODO let user change activity difficulty */},
       contentPadding = PaddingValues(all = 3.dp),
-      modifier = Modifier.width(80.dp).height(24.dp).testTag("elevatedTestTag"),
+      modifier = Modifier
+          .width(80.dp)
+          .height(24.dp)
+          .testTag("elevatedTestTag"),
       colors = ButtonDefaults.buttonColors(containerColor = difficultyColor)) {
         Text(
             activityToDisplay.difficulty.toString(),
@@ -360,13 +378,19 @@ fun TopBar(
     downloadActivity: (Activity) -> kotlin.Unit,
     navigateBack: () -> Unit
 ) {
+
+  val context = LocalContext.current
+
   Row(modifier = Modifier.fillMaxWidth().testTag("Top Bar")) {
     TopBarLogo(R.drawable.arrow_back) { navigateBack() }
     Spacer(modifier = Modifier.weight(1f))
     TopBarLogo(R.drawable.download_button) { downloadActivity(activityToDisplay) }
-    TopBarLogo(R.drawable.share) {}
+    TopBarLogo(R.drawable.share) {
+        shareActivity(activityToDisplay, context)
+    }
     TopBarLogo(R.drawable.favourite) {}
   }
+
 }
 
 // Logo of the top bar
@@ -376,7 +400,9 @@ fun TopBarLogo(logoPainterId: Int, isFriendProf: Boolean = false, f: () -> Unit)
     Icon(
         painter = painterResource(id = logoPainterId),
         contentDescription = "Top Bar logo $logoPainterId",
-        modifier = Modifier.width(26.dp).height(26.dp),
+        modifier = Modifier
+            .width(26.dp)
+            .height(26.dp),
         // put to white if bool else put to default color
         tint = if (isFriendProf) Color.White else MaterialTheme.colorScheme.onSurface)
   }
@@ -402,7 +428,10 @@ fun ActivityPicture() {
     Image(
         painter = painterResource(id = R.drawable.ellipse),
         contentDescription = "Soon Activity Picture",
-        modifier = Modifier.padding(5.dp).width(70.dp).height(70.dp))
+        modifier = Modifier
+            .padding(5.dp)
+            .width(70.dp)
+            .height(70.dp))
   }
 }
 
@@ -431,10 +460,11 @@ fun ElevatedActivityType(activityToDisplay: Activity) {
       onClick = {},
       contentPadding = PaddingValues(all = 3.dp),
       modifier =
-          Modifier.padding(3.dp)
-              .width(64.dp)
-              .height(20.dp)
-              .testTag("MoreInfoActivityTypeComposable"),
+      Modifier
+          .padding(3.dp)
+          .width(64.dp)
+          .height(20.dp)
+          .testTag("MoreInfoActivityTypeComposable"),
       colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
         Text(
             text = activityToDisplay.activityType.toString(),
@@ -466,7 +496,9 @@ fun AddRatingButton(
     ModalBottomSheet(
         onDismissRequest = { isReviewing.value = false }, modifier = Modifier.fillMaxWidth()) {
           Column(
-              modifier = Modifier.padding(30.dp).testTag("ModalBottomSheet"),
+              modifier = Modifier
+                  .padding(30.dp)
+                  .testTag("ModalBottomSheet"),
               horizontalAlignment = Alignment.CenterHorizontally) {
                 val selectedStarCount = remember { mutableIntStateOf(1) }
                 Text(
@@ -527,7 +559,10 @@ fun AddRatingButton(
                       isReviewing.value = false
                     },
                     modifier =
-                        Modifier.fillMaxWidth().padding(top = 10.dp).testTag("PublishButton"),
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 10.dp)
+                        .testTag("PublishButton"),
                     colors =
                         ButtonDefaults.buttonColors(
                             containerColor = PrimaryBlue, contentColor = Color.White)) {
@@ -546,11 +581,15 @@ fun AddRatingButton(
                 contentColor = Color.Black,
                 disabledContentColor = Color.Yellow,
                 disabledContainerColor = Color.Black),
-        modifier = Modifier.size(25.dp).testTag("AddRatingButton")) {
+        modifier = Modifier
+            .size(25.dp)
+            .testTag("AddRatingButton")) {
           Icon(
               painter = painterResource(id = R.drawable.plus),
               contentDescription = "Add Rating",
-              modifier = Modifier.width(16.dp).height(16.dp),
+              modifier = Modifier
+                  .width(16.dp)
+                  .height(16.dp),
               tint = Color.Black,
           )
         }
@@ -560,7 +599,9 @@ fun AddRatingButton(
 @Composable
 fun StarButtons(selectedStarCount: MutableState<Int>) {
   Row(
-      modifier = Modifier.padding(2.dp).testTag("StarButtons"),
+      modifier = Modifier
+          .padding(2.dp)
+          .testTag("StarButtons"),
       verticalAlignment = Alignment.CenterVertically) {
         for (i in 1..5) {
           val isSelected = i <= selectedStarCount.value
@@ -570,7 +611,9 @@ fun StarButtons(selectedStarCount: MutableState<Int>) {
                     painterResource(
                         id = if (isSelected) R.drawable.filled_star else R.drawable.empty_star),
                 contentDescription = "Star $i",
-                modifier = Modifier.width(16.dp).height(16.dp),
+                modifier = Modifier
+                    .width(16.dp)
+                    .height(16.dp),
                 tint = if (isSelected) MaterialTheme.colorScheme.primary else Color.Black)
           }
         }
@@ -581,10 +624,11 @@ fun StarButtons(selectedStarCount: MutableState<Int>) {
 fun RatingCard(rating: Rating, usersList: List<UserModel?>) {
   Card(
       modifier =
-          Modifier.fillMaxWidth()
-              .padding(vertical = 8.dp, horizontal = 16.dp)
-              .clickable(onClick = {})
-              .testTag("RatingCard"),
+      Modifier
+          .fillMaxWidth()
+          .padding(vertical = 8.dp, horizontal = 16.dp)
+          .clickable(onClick = {})
+          .testTag("RatingCard"),
       shape = RoundedCornerShape(8.dp),
       elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
       colors =
@@ -600,10 +644,12 @@ fun RatingCard(rating: Rating, usersList: List<UserModel?>) {
                 model = usersList.find { it?.userId == rating.userId }?.profilePictureUrl,
                 contentDescription = "Profile picture",
                 modifier =
-                    Modifier.size(30.dp)
-                        .clip(CircleShape)
-                        .border(
-                            2.dp, MaterialTheme.colorScheme.onPrimary, RoundedCornerShape(100.dp)),
+                Modifier
+                    .size(30.dp)
+                    .clip(CircleShape)
+                    .border(
+                        2.dp, MaterialTheme.colorScheme.onPrimary, RoundedCornerShape(100.dp)
+                    ),
                 contentScale = ContentScale.Crop,
                 error = painterResource(id = R.drawable.default_profile_icon))
             Spacer(modifier = Modifier.width(10.dp))

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -107,7 +107,7 @@
     <string name="ride">Radtour</string>
     <string name="recent_activities">Neueste Aktivitäten</string>
     <string name="share_title">Lasta : Aktivitäten teilen</string>
-    <string name="share_body">Hallo ! sieh dir diese Aktivität auf Lasta an :</string>
+    <string name="share_body">Hallo ! Sieh dir diese Aktivität auf Lasta an :</string>
     <string name="step_count">Schrittzahl</string>
     <string name="step_count_unavailable">Schrittzähler Nicht verfügbar</string>
     <string name="step_count_unsupported">Dieses Gerät unterstützt keine Schrittzählung.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -106,4 +106,6 @@
     <string name="advanced">Erweitert</string>
     <string name="ride">Radtour</string>
     <string name="recent_activities">Neueste Aktivitäten</string>
+    <string name="share_title">Lasta : Aktivitäten teilen</string>
+    <string name="share_body">Hallo ! sieh dir diese Aktivität auf Lasta an :</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -107,7 +107,7 @@
     <string name="ride">Tour</string>
     <string name="recent_activities">Activités récentes</string>
     <string name="share_title">Lasta : Partage d\'activité</string>
-    <string name="share_body">Hello ! Regardes cette activité sur Lasta :</string>
+    <string name="share_body">Hello ! Regarde cette activité sur Lasta :</string>
     <string name="step_count">Nombre de pas</string>
     <string name="step_count_unavailable">Compteur de pas indisponible</string>
     <string name="step_count_unsupported">Cet appareil ne prend pas en charge le comptage de pas </string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -106,4 +106,6 @@
     <string name="advanced">Avancé</string>
     <string name="ride">Tour</string>
     <string name="recent_activities">Activités récentes</string>
+    <string name="share_title">Lasta : Partage d\'activité</string>
+    <string name="share_body">Hello ! Regardes cette activité sur Lasta :</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,4 +146,5 @@
     <string name="step_count">Step Count</string>
     <string name="step_count_unavailable">Step Counter Not Available</string>
     <string name="step_count_unsupported">This device does not support step counting.</string>
+    <string name="share_base_url" translatable="false">https://lasta.jerem.ch/activity/</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,4 +139,6 @@
     <string name="advanced">Advanced</string>
     <string name="ride">Ride</string>
     <string name="recent_activities">Recent Activities</string>
+    <string name="share_title">Lasta : Activity Sharing</string>
+    <string name="share_body">"Hi ! Check out this activity on Lasta : "</string>
 </resources>


### PR DESCRIPTION
# Share Function for Activities
## Summary
This PR introduces a new function that launches an Android sharesheet for sharing activities within our app. The sharesheet includes the app's name and a link to the activity, and supports translations in both French and German. Additionally, the share button on the "More Info" screen now triggers this function.

## Details
- **Functionality** : A new function has been implemented that, given the app context and an activity, launches an Android sharesheet.
- **Sharesheet Content** : The sharesheet shares a text containing the app's name and a link to the activity. The content is translated into French and German.
- **Future enhancements** : Implement a system to open shared links directly within the app. The current share function already includes the link in the shared text, paving the way for this feature.
- **Content modification** : It is rather easy to change the text that is being shared, it should be straightforward to upgrade this functionnality in the future


## Recording
[Sharing PR.webm](https://github.com/LASTA-OUTDOOR/lasta/assets/94183393/211ad813-5c7e-4468-9545-430b0793c2ec)


