### PR TITLE
Bug fixed the "phantom user" issue

### DIFF
--- a/app/src/main/java/com/lastaoutdoor/lasta/ui/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/lastaoutdoor/lasta/ui/navigation/MainNavGraph.kt
@@ -317,7 +317,9 @@ fun NavGraphBuilder.addMainNavGraph(navController: NavHostController) {
             preferencesViewModel.clearPreferences()
             preferencesViewModel.updateIsLoggedIn(false)
             authViewModel.signOut()
-            navController.popBackStack()
+            // Pop backstack up to and including the main route, so that the user cannot press back
+            // button to get back in the app as a "phantom user"
+            navController.popBackStack(BaseRoute.Main.route, true)
             navController.navigate(BaseRoute.Login.route)
           },
           {
@@ -326,6 +328,9 @@ fun NavGraphBuilder.addMainNavGraph(navController: NavHostController) {
             authViewModel.signOut()
             authViewModel.deleteAccount()
             navController.popBackStack()
+            // Pop backstack up to and including the main route, so that the user cannot press back
+            // button to get back in the app as a "phantom user"
+            navController.popBackStack(BaseRoute.Main.route, true)
             navController.navigate(BaseRoute.Login.route)
           })
     }


### PR DESCRIPTION
Prevented the possibility to use the app while logged out by pressing the back button after signing out

It took me some time to tackle out the problem but basically I pop backstack up to and including the main route before getting back to the login screen. 
Thus, the backstack is empty (since the main route is the start of the graph) and the app just closes itself if the user presses the `back` button